### PR TITLE
feat: mdx

### DIFF
--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -17,33 +17,33 @@
 # Hello, Blazor MDX!
 This is **Markdown** with a Blazor component:
 
-<Button>
+<Button Variant=@(Button.Variants.Outline) disabled class=""bg-green-500"">
 Hello World from MDX
 </Button>
 
-<Separator />
-
-<NavLink>
-<Button>Other button</Button>
-</NavLink>
-
-<Separator />
-
-<Tabs>
-  <TabsList>
-    <TabsTrigger>Click</TabsTrigger>
-  </TabsList>
-  <TabsContent>Test</TabsContent>
-</Tabs>
-
-<Separator />
-
-<Button>Inline button</Button>
-
-## Test after
-like you can see we did rendered Markdown Razor
 ";
   /*
+  <Separator />
+
+  <NavLink>
+  <Button>Other button</Button>
+  </NavLink>
+
+  <Separator />
+
+  <Tabs>
+  <TabsList>
+  <TabsTrigger>Click</TabsTrigger>
+  </TabsList>
+  <TabsContent>Test</TabsContent>
+  </Tabs>
+
+  <Separator />
+
+  <Button>Inline button</Button>
+
+  ## Test after
+  like you can see we did rendered Markdown Razor
   */
 }
 

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -17,15 +17,28 @@
 # Hello, Blazor MDX!
 This is **Markdown** with a Blazor component:
 
-<Button>Hello World from MDX</Button>
+<Button>
+Hello World from MDX
+</Button>
 
 <Separator />
 
-<NavLink><Button>Other button</Button></NavLink>
+<NavLink>
+<Button>Other button</Button>
+</NavLink>
 
 <Separator />
 
-<Tabs><TabsList><TabsTrigger>Click</TabsTrigger></TabsList><TabsContent>Test</TabsContent></Tabs>
+<Tabs>
+  <TabsList>
+    <TabsTrigger>Click</TabsTrigger>
+  </TabsList>
+  <TabsContent>Test</TabsContent>
+</Tabs>
+
+<Separator />
+
+<Button>Inline button</Button>
 
 ## Test after
 like you can see we did rendered Markdown Razor

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -4,46 +4,7 @@
 
 <PageTitle>Home</PageTitle>
 
-@*
 <div class="flex flex-col gap-4">
   <QuickLinks Base=@(typeof(Pages.Examples.Examples)) />
 </div>
-*@
-
-<MdxRenderer Value="@(content)" />
-
-@code {
-  private string content = $@"
-# Hello, Blazor MDX!
-This is **Markdown** with a Blazor component:
-
-<Button Variant=@(Button.Variants.Outline) disabled class=""bg-green-500"">
-Hello World from MDX
-</Button>
-
-";
-  /*
-  <Separator />
-
-  <NavLink>
-  <Button>Other button</Button>
-  </NavLink>
-
-  <Separator />
-
-  <Tabs>
-  <TabsList>
-  <TabsTrigger>Click</TabsTrigger>
-  </TabsList>
-  <TabsContent>Test</TabsContent>
-  </Tabs>
-
-  <Separator />
-
-  <Button>Inline button</Button>
-
-  ## Test after
-  like you can see we did rendered Markdown Razor
-  */
-}
 

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -2,28 +2,27 @@
 
 <PageTitle>Home</PageTitle>
 
-<MdxRenderer Value="@(content)" />
-
-<p>@(typeof(Separator))</p>
-
 @*
 <div class="flex flex-col gap-4">
   <QuickLinks Base=@(typeof(Pages.Examples.Examples)) />
 </div>
 *@
 
+<MdxRenderer Value="@(content)" />
+
 @code {
   private string content = $@"
 # Hello, Blazor MDX!
 This is **Markdown** with a Blazor component:
 
-<Razor type=""{typeof(Separator)}"" />
+<Button>Hello World from MDX</Button>
 
-<Razor type=""{typeof(Button)}"" />
+<Separator />
+
+<Button>Other button</Button>
 
 ## Test after
 like you can see we did rendered Markdown Razor
 ";
 }
-
 

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -1,5 +1,7 @@
 ﻿@page "/"
 
+@using System.Reflection
+
 <PageTitle>Home</PageTitle>
 
 @*
@@ -19,10 +21,16 @@ This is **Markdown** with a Blazor component:
 
 <Separator />
 
-<Button>Other button</Button>
+<NavLink><Button>Other button</Button></NavLink>
+
+<Separator />
+
+<Tabs><TabsList><TabsTrigger>Click</TabsTrigger></TabsList><TabsContent>Test</TabsContent></Tabs>
 
 ## Test after
 like you can see we did rendered Markdown Razor
 ";
+  /*
+  */
 }
 

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -2,8 +2,28 @@
 
 <PageTitle>Home</PageTitle>
 
+<MdxRenderer Value="@(content)" />
+
+<p>@(typeof(Separator))</p>
+
+@*
 <div class="flex flex-col gap-4">
   <QuickLinks Base=@(typeof(Pages.Examples.Examples)) />
 </div>
+*@
+
+@code {
+  private string content = $@"
+# Hello, Blazor MDX!
+This is **Markdown** with a Blazor component:
+
+<Razor type=""{typeof(Separator)}"" />
+
+<Razor type=""{typeof(Button)}"" />
+
+## Test after
+like you can see we did rendered Markdown Razor
+";
+}
 
 

--- a/src/Pango.UI/Pango.UI.csproj
+++ b/src/Pango.UI/Pango.UI.csproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Markdig" Version="0.40.0" />
       <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="8.0.14" />
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.12" />
       <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.12" PrivateAssets="all" />

--- a/src/Pango.UI/Shared/Docs/MdxRenderer.cs
+++ b/src/Pango.UI/Shared/Docs/MdxRenderer.cs
@@ -94,6 +94,8 @@ public partial class MdxRenderer : ComponentBase
             var beforePlaceholder = html[lastIndex..component.Index];
             fragments.Add((lastIndex, new MdxFragment(Content: beforePlaceholder)));
 
+            Console.WriteLine($"MATCH: {component.Value}");
+
             var componentName =
                 component
                     .Groups.Values.Where(g => g.Name == "name")
@@ -163,7 +165,7 @@ public partial class MdxRenderer : ComponentBase
     }
 
     [GeneratedRegex(
-        @"<(?<name>[A-Z][A-Za-z0-9]*)(?<props>\s+[^>]*)?(?:>(?<content>.*?)</\k<name>>|/?>)",
+        @"(?s)<(?<name>[A-Z][A-Za-z0-9]*)(?<props>\s+[^>]*)?(?:>(?<content>.*?)</\k<name>>|/?>)",
         RegexOptions.Compiled
     )]
     private static partial Regex RazorComponentPattern();

--- a/src/Pango.UI/Shared/Docs/MdxRenderer.cs
+++ b/src/Pango.UI/Shared/Docs/MdxRenderer.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Markdig;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Pango.UI.Components;
+
+namespace Pango.UI.Shared.Docs;
+
+public interface IMdxFragment
+{
+    void Render(RenderTreeBuilder builder);
+    int GetIndex();
+}
+
+public record struct MdxFragment(int Index, string Content) : IMdxFragment
+{
+    public readonly int GetIndex() => Index + Content.Length;
+
+    public readonly void Render(RenderTreeBuilder builder)
+    {
+        builder.AddMarkupContent(0, Content);
+    }
+}
+
+public record struct MdxComponentFragment(
+    int Index,
+    string Content,
+    Type Type,
+    IEnumerable<KeyValuePair<string, object>>? Attributes
+) : IMdxFragment
+{
+    public readonly int GetIndex() => Index + Content.Length;
+
+    public readonly void Render(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(2, "class", "markdown-component");
+
+        builder.OpenComponent(3, Type);
+        builder.AddMultipleAttributes(4, Attributes);
+        builder.CloseComponent();
+
+        builder.CloseElement();
+    }
+}
+
+public class MdxRenderer : ComponentBase
+{
+    [Parameter]
+    public string? Value { get; set; }
+
+    private readonly MarkdownPipeline _pipeline;
+
+    private string _processedHtml = "";
+    private static int _counter = 0;
+
+    public MdxRenderer()
+    {
+        _pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (string.IsNullOrEmpty(Value))
+            return;
+
+        // Process Markdown
+        _processedHtml = ParseMarkdown(Value ?? "");
+    }
+
+    public string ParseMarkdown(string markdown)
+    {
+        // Convert Markdown to HTML
+        string html = Markdown.ToHtml(markdown, _pipeline);
+
+        return html;
+    }
+
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        Regex ComponentRegex = new(@"<Razor\b[^>]*?/>", RegexOptions.Compiled);
+
+        List<IMdxFragment> _htmlChunks = [];
+        int lastIndex = 0;
+        foreach (Match match in ComponentRegex.Matches(_processedHtml))
+        {
+            // Store HTML before the component
+            var beforePlaceholder = _processedHtml[lastIndex..match.Index];
+            _htmlChunks.Add(new MdxFragment(Index: lastIndex, Content: beforePlaceholder));
+
+            Console.WriteLine($"COMPONENT: {match.Value}");
+
+            // Store the component
+            Regex attributesRegex = new(@"\b([a-zA-Z0-9-]+)\s*=\s*""([^""]*)");
+            var a = attributesRegex.Match(match.Value);
+            var componentType = Type.GetType(a.Value.Split("\"").Last());
+            _htmlChunks.Add(
+                new MdxComponentFragment(
+                    Index: match.Index,
+                    Content: match.Value,
+                    Type: componentType!,
+                    null
+                )
+            );
+
+            Console.WriteLine($"\nBEFORE:{beforePlaceholder}\nCOMP:{a.Value}\n\n");
+
+            lastIndex = match.Index + match.Length;
+        }
+        // Add the remaining HTML after the last component
+        _htmlChunks.Add(
+            new MdxFragment(Index: lastIndex, Content: _processedHtml.Substring(lastIndex))
+        );
+
+        // Render Markdown content as raw HTML
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "markdown-body");
+
+        int seq = 2;
+        foreach (var fragment in _htmlChunks)
+        {
+            seq += fragment.GetIndex() + 1;
+
+            builder.OpenRegion(seq);
+            fragment.Render(builder);
+            builder.CloseRegion();
+        }
+
+        builder.CloseElement();
+
+        // Render detected Blazor components at the correct positions
+        /*
+        Type? componentType = Type.GetType($"BlazorMarkdown.Components.Counter");
+
+        if (componentType != null)
+        {
+            builder.OpenElement(3, "div");
+            builder.OpenComponent(5, componentType);
+            builder.CloseComponent();
+            builder.CloseElement();
+        }
+        */
+    }
+}

--- a/src/Pango.UI/Shared/Docs/MdxRenderer/MdxRenderer.razor
+++ b/src/Pango.UI/Shared/Docs/MdxRenderer/MdxRenderer.razor
@@ -1,0 +1,5 @@
+@namespace Pango.UI.Shared.Docs
+
+<div class="pango-ui-markdown flex flex-1 flex-col gap-4 w-full">
+  @RenderMarkdown
+</div>

--- a/src/Pango.UI/Shared/Docs/MdxRenderer/MdxRenderer.razor.cs
+++ b/src/Pango.UI/Shared/Docs/MdxRenderer/MdxRenderer.razor.cs
@@ -189,7 +189,7 @@ public partial class MdxRenderer : ComponentBase
         return fragments;
     }
 
-    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    protected void RenderMarkdown(RenderTreeBuilder builder)
     {
         var fragments = ResolveComponent(_processedHtml);
 
@@ -207,7 +207,7 @@ public partial class MdxRenderer : ComponentBase
             if (fragment is MdxComponentFragment)
             {
                 builder.OpenElement(0, "div");
-                builder.AddAttribute(1, "class", "markdown-component my-4");
+                builder.AddAttribute(1, "class", "markdown-component");
             }
 
             fragment.Render(builder);

--- a/src/Pango.UI/Shared/Docs/MdxRenderer/MdxRenderer.razor.css
+++ b/src/Pango.UI/Shared/Docs/MdxRenderer/MdxRenderer.razor.css
@@ -1,0 +1,183 @@
+.pango-ui-markdown {
+  color: var(--color-foreground);
+  background-color: var(--color-background);
+  font-family: system-ui, sans-serif;
+  line-height: 1.5;
+
+}
+
+::deep .markdown-component {
+
+  /*  &:not(:first-child)]:mt-6  */
+  &:not(:first-child) {
+    margin-top: 1.5rem;
+  }
+
+  /* mb-4  */
+  margin-bottom: 1rem;
+}
+
+/* Markdown Typography Styling - ShadCN-inspired */
+
+/* Headings */
+::deep h1 {
+  /* scroll-m-20 */
+  margin-top: 1.25rem;
+  /* Tailwind's default */
+  margin-bottom: 0.75rem;
+  /* text-3xl */
+  font-size: 1.875rem;
+  /* font-bold */
+  font-weight: 700;
+  /* tracking-tight */
+  letter-spacing: -0.02em;
+}
+
+::deep h2,
+::deep h3,
+::deep h4 {
+  /* scroll-m-20 */
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  /* Border bottom for subheadings */
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.5rem;
+}
+
+::deep h2 {
+  /* text-2xl */
+  font-size: 1.5rem;
+  font-weight: 700;
+  /* tracking-tight */
+  letter-spacing: -0.02em;
+}
+
+::deep h3 {
+  /* text-xl */
+  font-size: 1.25rem;
+  /* font-semibold */
+  font-weight: 600;
+  /* tracking-tight */
+  letter-spacing: -0.01em;
+}
+
+::deep h4 {
+  /* text-lg */
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+/* Paragraphs & Text */
+::deep p {
+  margin-bottom: 1rem;
+  color: var(--color-foreground);
+}
+
+::deep a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+::deep a:hover {
+  color: var(--color-primary-foreground);
+}
+
+/* Lists */
+::deep ul,
+::deep ol {
+  margin-bottom: 1rem;
+  /* pl-6 */
+  padding-left: 1.5rem;
+}
+
+::deep ul {
+  list-style-type: disc;
+}
+
+::deep ol {
+  list-style-type: decimal;
+}
+
+/* Blockquote */
+::deep blockquote {
+  margin: 1rem 0;
+  padding-left: 1rem;
+  border-left: 4px solid var(--color-border);
+  color: var(--color-muted-foreground);
+  font-style: italic;
+}
+
+/* Code Blocks */
+::deep pre {
+  padding: 0.75rem;
+  background-color: var(--color-muted);
+  color: var(--color-muted-foreground);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+}
+
+::deep code {
+  padding: 0.25rem 0.5rem;
+  /* text-sm */
+  font-family: monospace;
+  font-size: 0.875rem;
+  background-color: var(--color-muted);
+  color: var(--color-muted-foreground);
+  border-radius: var(--radius-sm);
+}
+
+/* Tables */
+::deep table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+::deep th,
+::deep td {
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+}
+
+::deep th {
+  background-color: var(--color-muted);
+  color: var(--color-muted-foreground);
+  font-weight: 600;
+}
+
+/* Images */
+::deep img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
+/* Horizontal Rule */
+::deep hr {
+  margin: 2rem 0;
+  border: none;
+  border-top: 1px solid var(--color-border);
+}
+
+/* Strong & Emphasis */
+::deep strong {
+  font-weight: 700;
+}
+
+::deep em {
+  font-style: italic;
+}
+
+/* Details / Summary */
+::deep details {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  background-color: var(--color-muted);
+  border-radius: var(--radius-md);
+}
+
+::deep summary {
+  font-weight: 600;
+  cursor: pointer;
+}


### PR DESCRIPTION
This PR introduces a `MDX Renderer` component. Its allow combine `Markdown` and `Blazor components`.

> [!WARNING]  
> This `MDX` implementation is only for `Pango.UI.Docs` and its not optimised for production projects, also there some limitations on `Parameters` and too complex components with deep nesting. Consider encapsulating big blocks in a single component.