### PR TITLE
feat: add Select component with form integration

### DIFF
--- a/src/Pango.UI/Components/Select/ISelect.cs
+++ b/src/Pango.UI/Components/Select/ISelect.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Pango.UI.Components;
+
+/// <summary>
+/// Non-generic interface for Select child components to access parent state
+/// </summary>
+public interface ISelect
+{
+    string State { get; }
+    string? SelectedText { get; }
+    string? Placeholder { get; }
+    bool Disabled { get; }
+    ElementReference SelectTriggerRef { get; set; }
+    ElementReference SelectContentRef { get; set; }
+    Task ToggleState();
+    Task OpenDropdown();
+    Task CloseDropdown();
+}

--- a/src/Pango.UI/Components/Select/Select.razor
+++ b/src/Pango.UI/Components/Select/Select.razor
@@ -1,0 +1,22 @@
+@namespace Pango.UI.Components
+@typeparam TValue
+@inherits InputBase<TValue>
+
+<div
+    @attributes="AdditionalAttributes"
+    class="@Tw([
+        "relative",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])"
+    data-state="@State">
+    <CascadingValue Value="(ISelect)this">
+        <CascadingValue Value="this">
+            @ChildContent
+        </CascadingValue>
+    </CascadingValue>
+
+    @* Hidden input for form submission (SSR support) *@
+    <input type="hidden"
+           name="@NameAttributeValue"
+           value="@CurrentValueAsString" />
+</div>

--- a/src/Pango.UI/Components/Select/Select.razor.cs
+++ b/src/Pango.UI/Components/Select/Select.razor.cs
@@ -1,0 +1,238 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.JSInterop;
+using TailwindMerge;
+
+namespace Pango.UI.Components;
+
+public partial class Select<TValue> : InputBase<TValue>, ISelect, IDisposable
+{
+    public ElementReference SelectTriggerRef { get; set; }
+    public ElementReference SelectContentRef { get; set; }
+
+    private IJSObjectReference? _jsSelectModule;
+    private IJSObjectReference? _jsSelectCleaner;
+    private DotNetObjectReference<Select<TValue>>? _csSelectRef;
+
+    private readonly List<SelectItem<TValue>> _items = [];
+
+    [Inject]
+    protected IJSRuntime JS { get; set; } = null!;
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? Placeholder { get; set; }
+
+    [Parameter]
+    public Placements Placement { get; set; } = Placements.BottomStart;
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+
+    public string State { get; private set; } = "closed";
+
+    public string? SelectedText { get; private set; }
+
+    /// <summary>
+    /// Exposes the current value for child components
+    /// </summary>
+    internal TValue? SelectedValue => CurrentValue;
+
+    public string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+
+    private static readonly Dictionary<Placements, string> _placements = new()
+    {
+        { Placements.BottomStart, "bottom-start" },
+        { Placements.TopStart, "top-start" },
+        { Placements.LeftStart, "left-start" },
+        { Placements.RightStart, "right-start" },
+        { Placements.BottomCenter, "bottom" },
+        { Placements.TopCenter, "top" },
+        { Placements.LeftCenter, "left" },
+        { Placements.RightCenter, "right" },
+        { Placements.BottomEnd, "bottom-end" },
+        { Placements.TopEnd, "top-end" },
+        { Placements.LeftEnd, "left-end" },
+        { Placements.RightEnd, "right-end" },
+    };
+
+    public enum Placements
+    {
+        BottomStart,
+        TopStart,
+        LeftStart,
+        RightStart,
+        BottomCenter,
+        TopCenter,
+        LeftCenter,
+        RightCenter,
+        BottomEnd,
+        TopEnd,
+        LeftEnd,
+        RightEnd,
+    }
+
+    protected override void OnInitialized()
+    {
+        _csSelectRef = DotNetObjectReference.Create(this);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _jsSelectModule = await JS.InvokeAsync<IJSObjectReference>(
+                "import",
+                "./Components/Select/Select.razor.js"
+            );
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    protected override bool TryParseValueFromString(
+        string? value,
+        [MaybeNullWhen(false)] out TValue result,
+        [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        var targetType = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+
+        if (targetType == typeof(string))
+        {
+            result = (TValue)(object)(value ?? string.Empty);
+            validationErrorMessage = null;
+            return true;
+        }
+
+        if (string.IsNullOrEmpty(value))
+        {
+            result = default!;
+            validationErrorMessage = null;
+            return true;
+        }
+
+        if (targetType.IsEnum)
+        {
+            if (Enum.TryParse(targetType, value, ignoreCase: true, out var enumResult))
+            {
+                result = (TValue)enumResult!;
+                validationErrorMessage = null;
+                return true;
+            }
+        }
+
+        try
+        {
+            result = (TValue)Convert.ChangeType(value, targetType)!;
+            validationErrorMessage = null;
+            return true;
+        }
+        catch
+        {
+            result = default!;
+            validationErrorMessage = $"The value '{value}' is not valid for {typeof(TValue).Name}.";
+            return false;
+        }
+    }
+
+    internal void RegisterItem(SelectItem<TValue> item)
+    {
+        if (!_items.Contains(item))
+        {
+            _items.Add(item);
+
+            // Set initial selected text if value matches
+            if (EqualityComparer<TValue>.Default.Equals(item.Value, SelectedValue))
+            {
+                SelectedText = item.GetDisplayText();
+                StateHasChanged();
+            }
+        }
+    }
+
+    internal void UnregisterItem(SelectItem<TValue> item)
+    {
+        _items.Remove(item);
+    }
+
+    internal async Task SelectItemAsync(TValue value, string text)
+    {
+        CurrentValue = value;
+        SelectedText = text;
+        await CloseDropdown();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task OpenDropdown()
+    {
+        if (Disabled) return;
+
+        State = "open";
+
+        if (_jsSelectModule is not null)
+        {
+            _jsSelectCleaner = await _jsSelectModule.InvokeAsync<IJSObjectReference>(
+                "InitializeSelect",
+                SelectTriggerRef,
+                SelectContentRef,
+                _placements[Placement],
+                _csSelectRef,
+                nameof(CloseDropdown),
+                nameof(HandleKeyboardSelect)
+            );
+        }
+    }
+
+    [JSInvokable]
+    public async Task CloseDropdown()
+    {
+        State = "closed";
+
+        if (_jsSelectCleaner is not null)
+        {
+            await _jsSelectCleaner.InvokeVoidAsync("CleanUp");
+            _jsSelectCleaner = null;
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    [JSInvokable]
+    public async Task HandleKeyboardSelect(int index)
+    {
+        if (index >= 0 && index < _items.Count)
+        {
+            var item = _items[index];
+            if (!item.Disabled)
+            {
+                await SelectItemAsync(item.Value, item.GetDisplayText());
+            }
+        }
+    }
+
+    public async Task ToggleState()
+    {
+        if (State == "open")
+        {
+            await CloseDropdown();
+        }
+        else
+        {
+            await OpenDropdown();
+        }
+    }
+
+    public void Dispose()
+    {
+        _csSelectRef?.Dispose();
+        _jsSelectModule?.DisposeAsync();
+        _jsSelectCleaner?.DisposeAsync();
+    }
+}

--- a/src/Pango.UI/Components/Select/Select.razor.js
+++ b/src/Pango.UI/Components/Select/Select.razor.js
@@ -1,0 +1,159 @@
+import { computePosition, flip, shift, autoUpdate } from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.4/+esm';
+
+export async function InitializeSelect(
+    triggerElement,
+    contentElement,
+    placement,
+    callbackInstance,
+    closeCallbackName,
+    selectCallbackName
+) {
+    async function updatePosition() {
+        const { x, y } = await computePosition(triggerElement, contentElement, {
+            placement,
+            middleware: [flip(), shift({ padding: 8 })],
+        });
+
+        Object.assign(contentElement.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+        });
+    }
+
+    const positionCleaner = autoUpdate(
+        triggerElement,
+        contentElement,
+        updatePosition,
+    );
+
+    // Show dialog (use show() instead of showModal() to avoid backdrop and scroll issues)
+    if (!contentElement.open && contentElement.show) {
+        contentElement.show();
+    }
+
+    // Track focused item index
+    let focusedIndex = -1;
+    const getItems = () => contentElement.querySelectorAll('[role="option"]:not([data-disabled="true"])');
+
+    function updateFocus() {
+        const items = getItems();
+        items.forEach((item, i) => {
+            if (i === focusedIndex) {
+                item.setAttribute('data-focused', 'true');
+                item.scrollIntoView({ block: 'nearest' });
+            } else {
+                item.removeAttribute('data-focused');
+            }
+        });
+    }
+
+    // Click outside to close
+    function handleClickOutside(e) {
+        if (!contentElement.contains(e.target) && !triggerElement.contains(e.target)) {
+            contentElement.close();
+        }
+    }
+
+    // Close event callback
+    function handleClose() {
+        callbackInstance.invokeMethodAsync(closeCallbackName);
+    }
+
+    // Keyboard navigation
+    function handleKeydown(e) {
+        const items = getItems();
+
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                focusedIndex = Math.min(focusedIndex + 1, items.length - 1);
+                if (focusedIndex < 0) focusedIndex = 0;
+                updateFocus();
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                focusedIndex = Math.max(focusedIndex - 1, 0);
+                updateFocus();
+                break;
+            case 'Enter':
+            case ' ':
+                e.preventDefault();
+                if (focusedIndex >= 0 && focusedIndex < items.length) {
+                    callbackInstance.invokeMethodAsync(selectCallbackName, focusedIndex);
+                }
+                break;
+            case 'Escape':
+                e.preventDefault();
+                contentElement.close();
+                break;
+            case 'Home':
+                e.preventDefault();
+                focusedIndex = 0;
+                updateFocus();
+                break;
+            case 'End':
+                e.preventDefault();
+                focusedIndex = items.length - 1;
+                updateFocus();
+                break;
+            case 'Tab':
+                e.preventDefault();
+                contentElement.close();
+                break;
+        }
+    }
+
+    // Type-ahead search
+    let searchBuffer = '';
+    let searchTimeout;
+
+    function handleTypeAhead(e) {
+        if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            const items = getItems();
+            clearTimeout(searchTimeout);
+            searchBuffer += e.key.toLowerCase();
+
+            const matchIndex = Array.from(items).findIndex(item =>
+                item.textContent.toLowerCase().startsWith(searchBuffer)
+            );
+
+            if (matchIndex >= 0) {
+                focusedIndex = matchIndex;
+                updateFocus();
+            }
+
+            searchTimeout = setTimeout(() => {
+                searchBuffer = '';
+            }, 500);
+        }
+    }
+
+    document.addEventListener('click', handleClickOutside);
+    contentElement.addEventListener('close', handleClose);
+    document.addEventListener('keydown', handleKeydown);
+    document.addEventListener('keydown', handleTypeAhead);
+
+    // Set initial focus to selected item or first item
+    const items = getItems();
+    const selectedItem = contentElement.querySelector('[data-selected="true"]');
+    if (selectedItem) {
+        focusedIndex = Array.from(items).indexOf(selectedItem);
+    } else if (items.length > 0) {
+        focusedIndex = 0;
+    }
+    updateFocus();
+
+    return {
+        CleanUp: () => {
+            if (contentElement.open && contentElement.close) {
+                contentElement.close();
+            }
+            positionCleaner();
+            document.removeEventListener('click', handleClickOutside);
+            contentElement.removeEventListener('close', handleClose);
+            document.removeEventListener('keydown', handleKeydown);
+            document.removeEventListener('keydown', handleTypeAhead);
+            clearTimeout(searchTimeout);
+        }
+    };
+}

--- a/src/Pango.UI/Components/Select/SelectContent.razor
+++ b/src/Pango.UI/Components/Select/SelectContent.razor
@@ -1,0 +1,32 @@
+@namespace Pango.UI.Components
+
+<dialog
+    @attributes="AdditionalAttributes"
+    @ref="_select.SelectContentRef"
+    role="listbox"
+    class="@Tw([
+        "absolute min-w-[8rem] w-max my-1 left-0 top-full overflow-hidden",
+        "rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 max-h-96 overflow-y-auto",
+        "animate-dialog-close zoom-out-95",
+        "open:animate-dialog-show zoom-in-95",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+    @ChildContent
+</dialog>
+
+@code {
+    [CascadingParameter]
+    private ISelect _select { get; set; } = null!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}

--- a/src/Pango.UI/Components/Select/SelectGroup.razor
+++ b/src/Pango.UI/Components/Select/SelectGroup.razor
@@ -1,0 +1,24 @@
+@namespace Pango.UI.Components
+
+<div
+    @attributes="AdditionalAttributes"
+    role="group"
+    class="@Tw([
+        "overflow-hidden p-1",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}

--- a/src/Pango.UI/Components/Select/SelectItem.razor
+++ b/src/Pango.UI/Components/Select/SelectItem.razor
@@ -1,0 +1,83 @@
+@namespace Pango.UI.Components
+@typeparam TValue
+@implements IDisposable
+
+<div
+    @attributes="AdditionalAttributes"
+    @onclick="HandleClick"
+    role="option"
+    aria-selected="@IsSelected"
+    data-selected="@IsSelected"
+    data-disabled="@Disabled"
+    tabindex="-1"
+    class="@Tw([
+        "relative flex w-full cursor-default select-none items-center gap-2",
+        "rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden",
+        "data-[focused=true]:bg-accent data-[focused=true]:text-accent-foreground",
+        "hover:bg-accent hover:text-accent-foreground",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+
+    @* Checkmark indicator *@
+    <span class="@Tw([
+        "absolute right-2 flex h-3.5 w-3.5 items-center justify-center",
+        IsSelected ? "opacity-100" : "opacity-0"
+    ])">
+        <i class="ph ph-check text-sm"></i>
+    </span>
+
+    @if (ChildContent is not null)
+    {
+        @ChildContent
+    }
+    else
+    {
+        @Text
+    }
+</div>
+
+@code {
+    [CascadingParameter]
+    private Select<TValue> _select { get; set; } = null!;
+
+    [Parameter, EditorRequired]
+    public required TValue Value { get; set; }
+
+    [Parameter]
+    public string? Text { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+
+    private bool IsSelected => EqualityComparer<TValue>.Default.Equals(Value, _select.SelectedValue);
+
+    protected override void OnInitialized()
+    {
+        _select.RegisterItem(this);
+    }
+
+    public void Dispose()
+    {
+        _select.UnregisterItem(this);
+    }
+
+    internal string GetDisplayText() => Text ?? Value?.ToString() ?? string.Empty;
+
+    private async Task HandleClick()
+    {
+        if (Disabled) return;
+        await _select.SelectItemAsync(Value, GetDisplayText());
+    }
+}

--- a/src/Pango.UI/Components/Select/SelectLabel.razor
+++ b/src/Pango.UI/Components/Select/SelectLabel.razor
@@ -1,0 +1,23 @@
+@namespace Pango.UI.Components
+
+<div
+    @attributes="AdditionalAttributes"
+    class="@Tw([
+        "px-2 py-1.5 text-xs text-muted-foreground font-semibold",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+    @ChildContent
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}

--- a/src/Pango.UI/Components/Select/SelectSeparator.razor
+++ b/src/Pango.UI/Components/Select/SelectSeparator.razor
@@ -1,0 +1,20 @@
+@namespace Pango.UI.Components
+
+<div
+    @attributes="AdditionalAttributes"
+    role="separator"
+    class="@Tw([
+        "bg-border pointer-events-none -mx-1 my-1 h-px",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+</div>
+
+@code {
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}

--- a/src/Pango.UI/Components/Select/SelectTrigger.razor
+++ b/src/Pango.UI/Components/Select/SelectTrigger.razor
@@ -1,0 +1,45 @@
+@namespace Pango.UI.Components
+
+<button
+    @attributes="AdditionalAttributes"
+    @ref="_select.SelectTriggerRef"
+    @onclick="_select.ToggleState"
+    type="button"
+    role="combobox"
+    aria-expanded="@(_select.State == "open")"
+    aria-haspopup="listbox"
+    disabled="@(_select.Disabled)"
+    data-state="@_select.State"
+    data-placeholder="@(string.IsNullOrEmpty(_select.SelectedText))"
+    class="@Tw([
+        "flex w-full items-center justify-between gap-2 rounded-md border border-input",
+        "bg-transparent px-3 py-2 text-sm shadow-xs whitespace-nowrap",
+        "transition-[color,box-shadow] outline-none",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[placeholder=true]:text-muted-foreground",
+        "[&>svg]:text-muted-foreground",
+        "dark:bg-input/30 dark:hover:bg-input/50",
+        "h-9",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+    @ChildContent
+
+    <i class="ph ph-caret-down text-sm opacity-50 shrink-0"></i>
+</button>
+
+@code {
+    [CascadingParameter]
+    private ISelect _select { get; set; } = null!;
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}

--- a/src/Pango.UI/Components/Select/SelectValue.razor
+++ b/src/Pango.UI/Components/Select/SelectValue.razor
@@ -1,0 +1,30 @@
+@namespace Pango.UI.Components
+
+<span
+    @attributes="AdditionalAttributes"
+    class="@Tw([
+        "line-clamp-1 pointer-events-none",
+        AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+    ])">
+    @if (!string.IsNullOrEmpty(_select.SelectedText))
+    {
+        @_select.SelectedText
+    }
+    else
+    {
+        @(_select.Placeholder ?? "Select an option...")
+    }
+</span>
+
+@code {
+    [CascadingParameter]
+    private ISelect _select { get; set; } = null!;
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}

--- a/src/Pango.UI/Docs/Components/Select/Examples/ExamplesSelectDefault.razor
+++ b/src/Pango.UI/Docs/Components/Select/Examples/ExamplesSelectDefault.razor
@@ -1,0 +1,23 @@
+<div class="flex flex-col gap-8 items-center">
+  @if (!string.IsNullOrEmpty(_selected))
+  {
+    <p class="text-4xl text-muted-foreground/50">
+      @_selected
+    </p>
+  }
+  <Select @bind-Value="_selected" Placeholder="Select a fruit">
+    <SelectTrigger>
+      <SelectValue />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem Value=@("apple") Text="Apple" />
+      <SelectItem Value=@("banana") Text="Banana" />
+      <SelectItem Value=@("cherry") Text="Cherry" />
+      <SelectItem Value=@("grape") Text="Grape" />
+    </SelectContent>
+  </Select>
+</div>
+
+@code {
+  string? _selected;
+}

--- a/src/Pango.UI/Docs/Components/Select/Examples/ExamplesSelectUsage.razor
+++ b/src/Pango.UI/Docs/Components/Select/Examples/ExamplesSelectUsage.razor
@@ -1,0 +1,64 @@
+<div class="flex flex-col gap-9 items-center">
+  <label class="w-full flex flex-col gap-1">
+    <span class="text-sm font-medium">
+      Basic
+    </span>
+    <Select @bind-Value="_framework" Placeholder="Select a framework">
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem Value=@("blazor") Text="Blazor" />
+        <SelectItem Value=@("react") Text="React" />
+        <SelectItem Value=@("vue") Text="Vue" />
+        <SelectItem Value=@("angular") Text="Angular" />
+      </SelectContent>
+    </Select>
+  </label>
+
+  <label class="w-full flex flex-col gap-1">
+    <span class="text-sm font-medium">
+      With Groups
+    </span>
+    <Select @bind-Value="_timezone" Placeholder="Select timezone">
+      <SelectTrigger class="w-[280px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>North America</SelectLabel>
+          <SelectItem Value=@("est") Text="Eastern Standard Time (EST)" />
+          <SelectItem Value=@("cst") Text="Central Standard Time (CST)" />
+          <SelectItem Value=@("pst") Text="Pacific Standard Time (PST)" />
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Europe</SelectLabel>
+          <SelectItem Value=@("gmt") Text="Greenwich Mean Time (GMT)" />
+          <SelectItem Value=@("cet") Text="Central European Time (CET)" />
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  </label>
+
+  <label class="w-full flex flex-col gap-1">
+    <span class="text-sm font-medium">
+      Disabled
+    </span>
+    <Select @bind-Value="_disabled" Disabled="true" Placeholder="Select a framework">
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem Value=@("blazor") Text="Blazor" />
+        <SelectItem Value=@("react") Text="React" />
+      </SelectContent>
+    </Select>
+  </label>
+</div>
+
+@code {
+  string? _framework;
+  string? _timezone;
+  string? _disabled = "blazor";
+}

--- a/src/Pango.UI/Docs/Components/Select/Select.mdx
+++ b/src/Pango.UI/Docs/Components/Select/Select.mdx
@@ -1,0 +1,38 @@
+```json :pango-ui-document-metadata
+{
+  "Title": "Select",
+  "Description": "Displays a list of options for the user to pick from, triggered by a button.",
+  "Featured": true,
+  "IsComponent": true,
+  "Tags": ["UI", "Form", "Native integration"],
+  "Sections": [
+    { "Title": "Installation" },
+    {
+      "Title": "Examples",
+      "Sections": [
+        { "Id": "usage", "Title": "Usage" }
+      ]
+    }
+  ]
+}
+```
+
+# Select
+
+Displays a list of options for the user to pick from, triggered by a button.
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesSelectDefault.razor" >
+    <ExamplesSelectDefault />
+</ComponentPreview>
+
+## Installation
+
+<Code Language="fish" class="py-2">dotnet pango add select</Code>
+
+## Examples
+
+### Usage
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesSelectUsage.razor" >
+    <ExamplesSelectUsage />
+</ComponentPreview>

--- a/src/Pango.UI/Pages/Examples/Example.razor
+++ b/src/Pango.UI/Pages/Examples/Example.razor
@@ -4,17 +4,32 @@
 
 @using Pango.UI.Docs.Components.Checkbox.Examples
 @using Pango.UI.Docs.Components.CheckboxGroup.Examples
+@using Pango.UI.Docs.Components.Select.Examples
+
+<h2 class="text-lg font-semibold mb-4">Select</h2>
+
+<ExamplesSelectDefault />
+
+<Separator class="my-8" />
+
+<ExamplesSelectUsage />
+
+<Separator class="my-8" />
+
+<h2 class="text-lg font-semibold mb-4">Checkbox</h2>
 
 <ExamplesCheckboxDefault/>
 
-<Separator />
+<Separator class="my-8" />
 
 <ExamplesCheckboxUsage />
 
-<Separator />
+<Separator class="my-8" />
+
+<h2 class="text-lg font-semibold mb-4">Checkbox Group</h2>
 
 <ExamplesCheckboxGroupDefault />
 
-<Separator />
+<Separator class="my-8" />
 
 <ExamplesCheckboxGroupUsage />

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -58,6 +58,7 @@
     new("Input", "./docs/input"),
     new("Label", "./docs/label"),
     new("Progress", "./docs/progress"),
+    new("Select", "./docs/select"),
     new("Separator", "./docs/separator"),
     new("Tabs", "./docs/tabs")
   ];


### PR DESCRIPTION
## Summary
- Implement Select component inheriting `InputBase<TValue>` for full EditForm support
- Add sub-components: SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel, SelectSeparator
- Use `ISelect` interface to simplify child component usage (no TValue needed on most children)
- Integrate Floating UI for dropdown positioning with keyboard navigation

## Test plan
- [x] Basic selection with string values
- [x] Selection with groups and separators
- [x] Disabled state
- [x] EditForm validation integration
- [x] Keyboard navigation (arrows, enter, escape)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)