### PR TITLE
feat: adding Calendar component

### DIFF
--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -2,7 +2,7 @@
 
 @typeparam TValue
 @using System.Globalization
-@using System.Reflection
+
 @inherits InputBase<TValue>
 
 <div
@@ -23,7 +23,25 @@
              ])">
       <i class="ph ph-caret-left text-foreground/60"></i>
     </button>
-    @_monthStart.ToString("MMMM yyyy")
+
+    @if (WithMonthAndYearSelection)
+    {
+      <CalendarMonthSelector
+        Label="@(_monthStart.ToString("MMMM"))"
+        AvailableMonths="DateTimeFormatInfo.CurrentInfo.MonthNames"
+        SelectedMonth="_monthStart.Month"
+        OnMonthChange="ChangeMonth"/>
+      <CalendarYearSelector
+        Label="@(_monthStart.ToString("yyyy"))"
+        AvailableYears="Enumerable.Range(1900, (_today.Year - 1899)).Reverse().ToArray()"
+        SelectedYear="_monthStart.Year"
+        OnYearChange="ChangeYear"/>
+    }
+    else
+    {
+      <span>@(_monthStart.ToString("MMMM yyyy"))</span>
+    }
+
     <button
       @onclick="NextMonth"
       class="@Tw([
@@ -33,7 +51,7 @@
       <i class="ph ph-caret-right text-foreground/60"></i>
     </button>
   </div>
-  <div class="@Tw(["grid grid-cols-7 m-4 gap-y-1 gap-x-0", FixedHeight ? "grid-rows-7" : null])">
+  <div class="@Tw(["grid grid-cols-7 m-4 gap-y-1", FixedHeight ? "grid-rows-7" : null])">
     @foreach (string day in GetWeekDaysNames())
     {
       <span class="text-xs text-foreground/70 text-center size-7">@day</span>
@@ -49,7 +67,7 @@
         @aria-disabled="@(day <= MinDate || day >= MaxDate)"
         @data-disabled="@(day <= MinDate || day >= MaxDate ? "" : null)"
         class="@Tw([
-                 "transition-colors cursor-pointer duration-200 size-7 text-sm text-muted rounded-sm hover:bg-accent hover:text-foreground",
+                 "transition-colors cursor-pointer duration-200 size-7 text-sm text-foreground/20 rounded-sm hover:bg-accent hover:text-foreground",
                  day == _today ? "bg-accent/50" : null,
                  IsSameMonth(day) && day > MinDate && day < MaxDate ? "text-foreground/80" : null,
                  day <= MinDate || day >= MaxDate ? "hover:bg-transparent hover:text-muted cursor-not-allowed" : null,
@@ -57,8 +75,8 @@
                  IsFromDate(day) ? "rounded-none rounded-l-md mx-1" : null,
                  IsToDate(day) ? "rounded-none rounded-r-md -mx-1" : null,
                  IsBetweenSelection(day) ? "bg-accent rounded-none w-full -mx-1 after:bg-accent" : null,
-                 IsBetweenSelection(day) && day.DayOfWeek == WeekStart ? "rounded-r-md" : null,
-                 IsBetweenSelection(day) && day.DayOfWeek == _weekEnd ? "rounded-l-md" : null
+                 IsBetweenSelection(day) && day.DayOfWeek == WeekStart ? "rounded-l-md" : null,
+                 IsBetweenSelection(day) && day.DayOfWeek == _weekEnd ? "rounded-r-md" : null
                ])"
         style="grid-column-start: @(index == 0 ? GetColStart(day.DayOfWeek) : null)">
         <time datetime="@day.Date.ToString("yyyy-MM-dd")">
@@ -75,8 +93,14 @@
   [Parameter] public TValue? SelectedDate { get; set; } = CastToTValue(_today);
   [Parameter] public CalendarDateRangeBehavior Behavior { get; set; } = CalendarDateRangeBehavior.KeepFromMoveTo;
   [Parameter] public bool FixedHeight { get; set; } = true;
+  [Parameter] public bool WithMonthAndYearSelection { get; set; }
+  /// <summary>
+  /// Only required for CalendarDateRange, requirement can be detected in primitive types nullability
+  /// </summary>
+  [Parameter] public bool Required { get; set; }
 
   [Parameter] public DayOfWeek WeekStart { get; set; } = DayOfWeek.Sunday;
+
   // [Parameter] public bool CanSelectOneDateOnDateRange { get; set; } = true;
   [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
   [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
@@ -181,9 +205,7 @@
 
   private void HandleNewRangeBehavior(DateTime day, CalendarDateRange range)
   {
-    NullabilityInfo nullability = _nullabilityInfoContext.Create(GetType().GetProperty(nameof(SelectedDate))!);
-
-    if (day == range.From && _rangeTo is null && nullability.ReadState == NullabilityState.Nullable)
+    if (day == range.From && _rangeTo is null && !Required)
     {
       _rangeFrom = null;
       _rangeTo = null;
@@ -218,9 +240,7 @@
 
   private void HandleSameRangeBehavior(DateTime day, CalendarDateRange range)
   {
-    NullabilityInfo nullability = _nullabilityInfoContext.Create(GetType().GetProperty(nameof(SelectedDate))!);
-
-    if (day == _rangeFrom && _rangeTo is null && nullability.ReadState == NullabilityState.Nullable)
+    if (day == _rangeFrom && _rangeTo is null && !Required)
     {
       _rangeFrom = null;
       _rangeTo = null;
@@ -252,6 +272,24 @@
 
     SelectedDate = (TValue)(object)range;
     CurrentValue = (TValue)(object)range;
+  }
+
+  private void ChangeMonth(int month)
+  {
+    _monthStart = new DateTime(_monthStart.Year, month, 1);
+    _monthEnd = new DateTime(_monthStart.Year, month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+    _daysOfCurrentMonth = GetEachDayOfInterval(
+      GetExtendedDateAtFirstWeek(_monthStart, WeekStart),
+      GetExtendedDateAtLastWeek(_monthEnd, _weekEnd)).ToList();
+  }
+
+  private void ChangeYear(int year)
+  {
+    _monthStart = new DateTime(year, _monthStart.Month, 1);
+    _monthEnd = new DateTime(year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+    _daysOfCurrentMonth = GetEachDayOfInterval(
+      GetExtendedDateAtFirstWeek(_monthStart, WeekStart),
+      GetExtendedDateAtLastWeek(_monthEnd, _weekEnd)).ToList();
   }
 
   private void PreviousMonth()

--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -1,0 +1,188 @@
+@namespace Pango.UI.Components
+
+@typeparam TValue
+@using System.Globalization
+@inherits InputBase<TValue>
+
+<div
+  @attributes="AdditionalAttributes"
+  @itemtype="_typeAttributeValue"
+  class="@Tw([
+           "max-w-72 border border-border rounded-md",
+           AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+         ])"
+  @ref="Element">
+
+  <div class="w-full flex items-center justify-between px-4 py-2 border-b border-border">
+    <button
+      @onclick="PreviousMonth"
+      class="@Tw([
+               "cursor-pointer transition-colors duration-200 size-7 rounded-md bg-transparent hover:bg-accent hover:text-foreground",
+               !CheckPreviousMonth() ? "opacity-50 cursor-not-allowed hover:bg-transparent" : null
+             ])">
+      <i class="ph ph-caret-left text-foreground/60"></i>
+    </button>
+    @_monthStart.ToString("MMMM yyyy")
+    <button
+      @onclick="NextMonth"
+      class="@Tw([
+               "cursor-pointer transition-colors duration-200 size-7 rounded-md bg-transparent hover:bg-accent hover:text-foreground",
+               !CheckNextMonth() ? "opacity-50 cursor-not-allowed hover:bg-transparent" : null
+             ])">
+      <i class="ph ph-caret-right text-foreground/60"></i>
+    </button>
+  </div>
+  <div class="@Tw(["grid grid-cols-7 m-4 gap-2", FixedHeight ? "grid-rows-7" : null])">
+    @foreach (string day in CultureInfo.CurrentCulture.DateTimeFormat.AbbreviatedDayNames)
+    {
+      <span class="text-xs text-foreground/70 text-center">@day</span>
+    }
+
+    @foreach (var (day, index) in _daysOfCurrentMonth.Select((item, i) => (item, i)))
+    {
+      <button
+        type="button"
+        @onclick:preventDefault
+        @onclick="() => OnSelectedDateChange(day)"
+        @disabled="@(day <= MinDate || day >= MaxDate)"
+        @aria-disabled="@(day <= MinDate || day >= MaxDate)"
+        @data-disabled="@(day <= MinDate || day >= MaxDate ? "" : null)"
+        class="@Tw([
+                 "transition-colors cursor-pointer duration-200 size-7 text-sm text-muted rounded-sm hover:bg-accent hover:text-foreground",
+                 IsSameMonth(day) && day > MinDate && day < MaxDate ? "text-foreground/80" : null,
+                 day <= MinDate || day >= MaxDate ? "hover:bg-transparent hover:text-muted cursor-not-allowed" : null,
+                 index == 0 ? ColWeekShift[day.DayOfWeek] : null,
+                 day == CastToDateTime(SelectedDate) ? "bg-primary text-primary-foreground hover:bg-primary/60 hover:text-primary-foreground" : null,
+               ])">
+        <time datetime="@day.Date.ToString("yyyy-MM-dd")">
+          @day.Day
+        </time>
+      </button>
+    }
+  </div>
+</div>
+
+@code {
+  private static readonly DateTime _today = DateTime.Now.Date;
+
+  [Parameter] public TValue? SelectedDate { get; set; } = CastToTValue(_today);
+  [Parameter] public bool FixedHeight { get; set; } = true;
+  [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
+  [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
+
+  private DateTime _monthStart;
+  private DateTime _monthEnd;
+
+  private List<DateTime> _daysOfCurrentMonth;
+
+  protected override void OnInitialized()
+  {
+    base.OnInitialized();
+    DateTime? date = CastToDateTime(SelectedDate);
+
+    _monthStart = new(date?.Year ?? _today.Year, date?.Month ?? _today.Month, 1);
+
+    _monthEnd = new(
+      _monthStart.Year,
+      _monthStart.Month,
+      DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month)
+    );
+
+    _daysOfCurrentMonth = GetEachDayOfInterval(
+      GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
+      GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
+
+    CurrentValue = SelectedDate;
+  }
+
+  protected override void OnParametersSet()
+  {
+    (_typeAttributeValue, _format, var formatDescription) = Type switch
+    {
+      InputDateType.Date => ("date", DateFormat, "date"),
+      InputDateType.DateTimeLocal => ("datetime-local", DateTimeLocalFormat, "date and time"),
+      InputDateType.Month => ("month", MonthFormat, "year and month"),
+      InputDateType.Time => ("time", TimeFormat, "time"),
+      _ => throw new InvalidOperationException($"Unsupported {nameof(InputDateType)} '{Type}'.")
+    };
+
+    _parsingErrorMessage = string.IsNullOrEmpty(ParsingErrorMessage)
+      ? $"The {{0}} field must be a {formatDescription}."
+      : ParsingErrorMessage;
+
+    SelectedDate = CurrentValue;
+  }
+
+  private void OnSelectedDateChange(DateTime day)
+  {
+    if (day <= MinDate || day >= MaxDate) return;
+
+    if (Equals(SelectedDate, CastToTValue(day)) && Nullable.GetUnderlyingType(typeof(TValue)) != null)
+    {
+      SelectedDate = default;
+    }
+    else
+    {
+      SelectedDate = CastToTValue(day);
+    }
+
+    CurrentValue = SelectedDate;
+  }
+
+  private bool CheckPreviousMonth()
+  {
+    DateTime date;
+
+    if (DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month) > MinDate.Day)
+    {
+      date = new(_monthStart.Year, _monthStart.Month, MinDate.Day);
+    }
+    else
+    {
+      date = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+    }
+
+    date = date.AddMonths(-1);
+    return date >= MinDate && _daysOfCurrentMonth.All(d => d != date);
+  }
+
+  private void PreviousMonth()
+  {
+    if (!CheckPreviousMonth()) return;
+
+    _monthStart = _monthStart.AddMonths(-1);
+    _monthEnd = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+    _daysOfCurrentMonth = GetEachDayOfInterval(
+      GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
+      GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
+  }
+
+  private bool CheckNextMonth()
+  {
+    DateTime date;
+
+    if (DateTime.DaysInMonth(_monthEnd.Year, _monthEnd.Month) > MaxDate.Day)
+    {
+      date = new(_monthEnd.Year, _monthEnd.Month, MaxDate.Day);
+    }
+    else
+    {
+      date = new(_monthEnd.Year, _monthEnd.Month, DateTime.DaysInMonth(_monthEnd.Year, _monthEnd.Month));
+    }
+    
+    date = date.AddMonths(1);
+    return date <= MaxDate && _daysOfCurrentMonth.All(d => d != date);
+  }
+
+  private void NextMonth()
+  {
+    if (!CheckNextMonth()) return;
+
+    _monthStart = _monthStart.AddMonths(1);
+    _monthEnd = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+    _daysOfCurrentMonth = GetEachDayOfInterval(
+      GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
+      GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
+  }
+
+}

--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -102,8 +102,6 @@
   public bool Required { get; set; }
 
   [Parameter] public DayOfWeek WeekStart { get; set; } = DayOfWeek.Sunday;
-
-  // [Parameter] public bool CanSelectOneDateOnDateRange { get; set; } = true;
   [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
   [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
 

--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -2,6 +2,7 @@
 
 @typeparam TValue
 @using System.Globalization
+@using System.Reflection
 @inherits InputBase<TValue>
 
 <div
@@ -32,10 +33,10 @@
       <i class="ph ph-caret-right text-foreground/60"></i>
     </button>
   </div>
-  <div class="@Tw(["grid grid-cols-7 m-4 gap-2", FixedHeight ? "grid-rows-7" : null])">
+  <div class="@Tw(["grid grid-cols-7 m-4 gap-y-1 gap-x-0", FixedHeight ? "grid-rows-7" : null])">
     @foreach (string day in CultureInfo.CurrentCulture.DateTimeFormat.AbbreviatedDayNames)
     {
-      <span class="text-xs text-foreground/70 text-center">@day</span>
+      <span class="text-xs text-foreground/70 text-center size-7">@day</span>
     }
 
     @foreach (var (day, index) in _daysOfCurrentMonth.Select((item, i) => (item, i)))
@@ -49,10 +50,16 @@
         @data-disabled="@(day <= MinDate || day >= MaxDate ? "" : null)"
         class="@Tw([
                  "transition-colors cursor-pointer duration-200 size-7 text-sm text-muted rounded-sm hover:bg-accent hover:text-foreground",
+                 day == _today ? "bg-accent/50" : null,
                  IsSameMonth(day) && day > MinDate && day < MaxDate ? "text-foreground/80" : null,
                  day <= MinDate || day >= MaxDate ? "hover:bg-transparent hover:text-muted cursor-not-allowed" : null,
                  index == 0 ? ColWeekShift[day.DayOfWeek] : null,
-                 day == CastToDateTime(SelectedDate) ? "bg-primary text-primary-foreground hover:bg-primary/60 hover:text-primary-foreground" : null,
+                 IsDaySelected(day) ? "bg-primary text-primary-foreground hover:bg-primary/60 hover:text-primary-foreground" : null,
+                 IsFromDate(day) ? "rounded-none rounded-l-md mx-1" : null,
+                 IsToDate(day) ? "rounded-none rounded-r-md -mx-1" : null,
+                 IsBetweenSelection(day) ? "bg-accent rounded-none w-full -mx-1 after:bg-accent" : null,
+                 IsBetweenSelection(day) && day.DayOfWeek is DayOfWeek.Saturday ? "rounded-r-md" : null,
+                 IsBetweenSelection(day) && day.DayOfWeek is DayOfWeek.Sunday ? "rounded-l-md" : null
                ])">
         <time datetime="@day.Date.ToString("yyyy-MM-dd")">
           @day.Day
@@ -66,19 +73,23 @@
   private static readonly DateTime _today = DateTime.Now.Date;
 
   [Parameter] public TValue? SelectedDate { get; set; } = CastToTValue(_today);
+  [Parameter] public CalendarDateRangeBehavior Behavior { get; set; } = CalendarDateRangeBehavior.KeepFromMoveTo;
   [Parameter] public bool FixedHeight { get; set; } = true;
+  // [Parameter] public bool CanSelectOneDateOnDateRange { get; set; } = true;
   [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
   [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
 
   private DateTime _monthStart;
   private DateTime _monthEnd;
+  private DateTime? _rangeFrom;
+  private DateTime? _rangeTo;
 
-  private List<DateTime> _daysOfCurrentMonth;
+  private List<DateTime> _daysOfCurrentMonth = [];
 
   protected override void OnInitialized()
   {
     base.OnInitialized();
-    DateTime? date = CastToDateTime(SelectedDate);
+    (DateTime? date, _) = CastToDateTime(SelectedDate);
 
     _monthStart = new(date?.Year ?? _today.Year, date?.Month ?? _today.Month, 1);
 
@@ -93,30 +104,42 @@
       GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
 
     CurrentValue = SelectedDate;
+
+    if (!_isRangeMode) return;
+
+    CalendarDateRange? range = (CalendarDateRange?)(object?)CurrentValue;
+    _rangeFrom = range?.From;
+    _rangeTo = range?.To;
   }
 
   protected override void OnParametersSet()
   {
-    (_typeAttributeValue, _format, var formatDescription) = Type switch
+    if (SelectedDate is not null && CurrentValue is not null && !Equals(SelectedDate, CurrentValue))
     {
-      InputDateType.Date => ("date", DateFormat, "date"),
-      InputDateType.DateTimeLocal => ("datetime-local", DateTimeLocalFormat, "date and time"),
-      InputDateType.Month => ("month", MonthFormat, "year and month"),
-      InputDateType.Time => ("time", TimeFormat, "time"),
-      _ => throw new InvalidOperationException($"Unsupported {nameof(InputDateType)} '{Type}'.")
-    };
+      CurrentValue = SelectedDate;
+    }
 
-    _parsingErrorMessage = string.IsNullOrEmpty(ParsingErrorMessage)
-      ? $"The {{0}} field must be a {formatDescription}."
-      : ParsingErrorMessage;
+    if (CurrentValue is not null) return;
 
-    SelectedDate = CurrentValue;
+    SelectedDate = default;
   }
 
   private void OnSelectedDateChange(DateTime day)
   {
     if (day <= MinDate || day >= MaxDate) return;
 
+    if (_isRangeMode)
+    {
+      HandleDateRangeSelection(day);
+    }
+    else
+    {
+      HandleSingleDateSelection(day);
+    }
+  }
+
+  private void HandleSingleDateSelection(DateTime day)
+  {
     if (Equals(SelectedDate, CastToTValue(day)) && Nullable.GetUnderlyingType(typeof(TValue)) != null)
     {
       SelectedDate = default;
@@ -129,21 +152,99 @@
     CurrentValue = SelectedDate;
   }
 
-  private bool CheckPreviousMonth()
+  private void HandleDateRangeSelection(DateTime day)
   {
-    DateTime date;
-
-    if (DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month) > MinDate.Day)
+    CalendarDateRange range = (CalendarDateRange?)(object?)CurrentValue ?? new();
+    CalendarDateRange newRange = new()
     {
-      date = new(_monthStart.Year, _monthStart.Month, MinDate.Day);
+      From = range.From,
+      To = range.To,
+    };
+
+    switch (Behavior)
+    {
+      case CalendarDateRangeBehavior.AlwaysSelectNewRange:
+        HandleNewRangeBehavior(day, newRange);
+        break;
+      case CalendarDateRangeBehavior.KeepFromMoveTo:
+        HandleSameRangeBehavior(day, newRange);
+        break;
+      default:
+        throw new ArgumentOutOfRangeException();
+    }
+  }
+
+  private void HandleNewRangeBehavior(DateTime day, CalendarDateRange range)
+  {
+    NullabilityInfo nullability = _nullabilityInfoContext.Create(GetType().GetProperty(nameof(SelectedDate))!);
+    if (day == range.From && _rangeTo is null && nullability.ReadState == NullabilityState.Nullable)
+    {
+      _rangeFrom = null;
+      _rangeTo = null;
+      SelectedDate = default;
+      CurrentValue = default;
+      return;
+    }
+
+    if (day == range.From) return;
+
+    if (_rangeFrom.HasValue && _rangeTo.HasValue)
+    {
+      _rangeFrom = day;
+      range.From = day;
+      _rangeTo = null;
+      range.To = null;
+    }
+    else if (!_rangeFrom.HasValue || day < _rangeFrom.Value)
+    {
+      _rangeFrom = day;
+      range.From = day;
     }
     else
     {
-      date = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+      _rangeTo = day;
+      range.To = day;
     }
 
-    date = date.AddMonths(-1);
-    return date >= MinDate && _daysOfCurrentMonth.All(d => d != date);
+    SelectedDate = (TValue)(object)range;
+    CurrentValue = (TValue)(object)range;
+  }
+
+  private void HandleSameRangeBehavior(DateTime day, CalendarDateRange range)
+  {
+    NullabilityInfo nullability = _nullabilityInfoContext.Create(GetType().GetProperty(nameof(SelectedDate))!);
+    if (day == _rangeFrom && _rangeTo is null && nullability.ReadState == NullabilityState.Nullable)
+    {
+      _rangeFrom = null;
+      _rangeTo = null;
+      SelectedDate = default;
+      CurrentValue = default;
+      return;
+    }
+
+    if (!_rangeFrom.HasValue || (day == range.From || day == range.To))
+    {
+      _rangeFrom = day;
+      range.From = day;
+      _rangeTo = null;
+      range.To = null;
+    }
+    else
+    {
+      if (day < _rangeFrom)
+      {
+        _rangeFrom = day;
+        range.From = day;
+      }
+      else
+      {
+        _rangeTo = day;
+        range.To = day;
+      }
+    }
+
+    SelectedDate = (TValue)(object)range;
+    CurrentValue = (TValue)(object)range;
   }
 
   private void PreviousMonth()
@@ -155,23 +256,6 @@
     _daysOfCurrentMonth = GetEachDayOfInterval(
       GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
       GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
-  }
-
-  private bool CheckNextMonth()
-  {
-    DateTime date;
-
-    if (DateTime.DaysInMonth(_monthEnd.Year, _monthEnd.Month) > MaxDate.Day)
-    {
-      date = new(_monthEnd.Year, _monthEnd.Month, MaxDate.Day);
-    }
-    else
-    {
-      date = new(_monthEnd.Year, _monthEnd.Month, DateTime.DaysInMonth(_monthEnd.Year, _monthEnd.Month));
-    }
-    
-    date = date.AddMonths(1);
-    return date <= MaxDate && _daysOfCurrentMonth.All(d => d != date);
   }
 
   private void NextMonth()

--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -34,7 +34,7 @@
     </button>
   </div>
   <div class="@Tw(["grid grid-cols-7 m-4 gap-y-1 gap-x-0", FixedHeight ? "grid-rows-7" : null])">
-    @foreach (string day in CultureInfo.CurrentCulture.DateTimeFormat.AbbreviatedDayNames)
+    @foreach (string day in GetWeekDaysNames())
     {
       <span class="text-xs text-foreground/70 text-center size-7">@day</span>
     }
@@ -53,14 +53,14 @@
                  day == _today ? "bg-accent/50" : null,
                  IsSameMonth(day) && day > MinDate && day < MaxDate ? "text-foreground/80" : null,
                  day <= MinDate || day >= MaxDate ? "hover:bg-transparent hover:text-muted cursor-not-allowed" : null,
-                 index == 0 ? ColWeekShift[day.DayOfWeek] : null,
                  IsDaySelected(day) ? "bg-primary text-primary-foreground hover:bg-primary/60 hover:text-primary-foreground" : null,
                  IsFromDate(day) ? "rounded-none rounded-l-md mx-1" : null,
                  IsToDate(day) ? "rounded-none rounded-r-md -mx-1" : null,
                  IsBetweenSelection(day) ? "bg-accent rounded-none w-full -mx-1 after:bg-accent" : null,
-                 IsBetweenSelection(day) && day.DayOfWeek is DayOfWeek.Saturday ? "rounded-r-md" : null,
-                 IsBetweenSelection(day) && day.DayOfWeek is DayOfWeek.Sunday ? "rounded-l-md" : null
-               ])">
+                 IsBetweenSelection(day) && day.DayOfWeek == WeekStart ? "rounded-r-md" : null,
+                 IsBetweenSelection(day) && day.DayOfWeek == _weekEnd ? "rounded-l-md" : null
+               ])"
+        style="grid-column-start: @(index == 0 ? GetColStart(day.DayOfWeek) : null)">
         <time datetime="@day.Date.ToString("yyyy-MM-dd")">
           @day.Day
         </time>
@@ -75,10 +75,13 @@
   [Parameter] public TValue? SelectedDate { get; set; } = CastToTValue(_today);
   [Parameter] public CalendarDateRangeBehavior Behavior { get; set; } = CalendarDateRangeBehavior.KeepFromMoveTo;
   [Parameter] public bool FixedHeight { get; set; } = true;
+
+  [Parameter] public DayOfWeek WeekStart { get; set; } = DayOfWeek.Sunday;
   // [Parameter] public bool CanSelectOneDateOnDateRange { get; set; } = true;
   [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
   [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
 
+  private DayOfWeek _weekEnd;
   private DateTime _monthStart;
   private DateTime _monthEnd;
   private DateTime? _rangeFrom;
@@ -89,6 +92,8 @@
   protected override void OnInitialized()
   {
     base.OnInitialized();
+    _weekEnd = (DayOfWeek)((int)(WeekStart + 6) % 7);
+
     (DateTime? date, _) = CastToDateTime(SelectedDate);
 
     _monthStart = new(date?.Year ?? _today.Year, date?.Month ?? _today.Month, 1);
@@ -100,8 +105,8 @@
     );
 
     _daysOfCurrentMonth = GetEachDayOfInterval(
-      GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
-      GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
+      GetExtendedDateAtFirstWeek(_monthStart, WeekStart),
+      GetExtendedDateAtLastWeek(_monthEnd, _weekEnd)).ToList();
 
     CurrentValue = SelectedDate;
 
@@ -177,6 +182,7 @@
   private void HandleNewRangeBehavior(DateTime day, CalendarDateRange range)
   {
     NullabilityInfo nullability = _nullabilityInfoContext.Create(GetType().GetProperty(nameof(SelectedDate))!);
+
     if (day == range.From && _rangeTo is null && nullability.ReadState == NullabilityState.Nullable)
     {
       _rangeFrom = null;
@@ -213,6 +219,7 @@
   private void HandleSameRangeBehavior(DateTime day, CalendarDateRange range)
   {
     NullabilityInfo nullability = _nullabilityInfoContext.Create(GetType().GetProperty(nameof(SelectedDate))!);
+
     if (day == _rangeFrom && _rangeTo is null && nullability.ReadState == NullabilityState.Nullable)
     {
       _rangeFrom = null;
@@ -254,8 +261,8 @@
     _monthStart = _monthStart.AddMonths(-1);
     _monthEnd = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
     _daysOfCurrentMonth = GetEachDayOfInterval(
-      GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
-      GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
+      GetExtendedDateAtFirstWeek(_monthStart, WeekStart),
+      GetExtendedDateAtLastWeek(_monthEnd, _weekEnd)).ToList();
   }
 
   private void NextMonth()
@@ -265,8 +272,8 @@
     _monthStart = _monthStart.AddMonths(1);
     _monthEnd = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
     _daysOfCurrentMonth = GetEachDayOfInterval(
-      GetExtendedDateAtFirstWeek(_monthStart, DayOfWeek.Sunday),
-      GetExtendedDateAtLastWeek(_monthEnd, DayOfWeek.Saturday)).ToList();
+      GetExtendedDateAtFirstWeek(_monthStart, WeekStart),
+      GetExtendedDateAtLastWeek(_monthEnd, _weekEnd)).ToList();
   }
 
 }

--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -2,6 +2,7 @@
 
 @typeparam TValue
 @using System.Globalization
+@using System.Text.Json
 
 @inherits InputBase<TValue>
 
@@ -28,12 +29,12 @@
     {
       <CalendarMonthSelector
         Label="@(_monthStart.ToString("MMMM"))"
-        AvailableMonths="DateTimeFormatInfo.CurrentInfo.MonthNames"
+        AvailableMonths="GetAvailableMonths()"
         SelectedMonth="_monthStart.Month"
         OnMonthChange="ChangeMonth"/>
       <CalendarYearSelector
         Label="@(_monthStart.ToString("yyyy"))"
-        AvailableYears="Enumerable.Range(1900, (_today.Year - 1899)).Reverse().ToArray()"
+        AvailableYears="GetAvailableYears()"
         SelectedYear="_monthStart.Year"
         OnYearChange="ChangeYear"/>
     }
@@ -90,14 +91,15 @@
 @code {
   private static readonly DateTime _today = DateTime.Now.Date;
 
-  [Parameter] public TValue? SelectedDate { get; set; } = CastToTValue(_today);
   [Parameter] public CalendarDateRangeBehavior Behavior { get; set; } = CalendarDateRangeBehavior.KeepFromMoveTo;
   [Parameter] public bool FixedHeight { get; set; } = true;
   [Parameter] public bool WithMonthAndYearSelection { get; set; }
+
   /// <summary>
   /// Only required for CalendarDateRange, requirement can be detected in primitive types nullability
   /// </summary>
-  [Parameter] public bool Required { get; set; }
+  [Parameter]
+  public bool Required { get; set; }
 
   [Parameter] public DayOfWeek WeekStart { get; set; } = DayOfWeek.Sunday;
 
@@ -116,23 +118,28 @@
   protected override void OnInitialized()
   {
     base.OnInitialized();
+
     _weekEnd = (DayOfWeek)((int)(WeekStart + 6) % 7);
 
-    (DateTime? date, _) = CastToDateTime(SelectedDate);
+    (DateTime? date, _) = CastToDateTime(CurrentValue);
+    if (date.HasValue && date.Value <= DateTime.MinValue)
+    {
+      CurrentValue = CastToTValue(_today);
+    }
 
-    _monthStart = new(date?.Year ?? _today.Year, date?.Month ?? _today.Month, 1);
+    DateTime baseDate = date.HasValue && date.Value > DateTime.MinValue ? date.Value : _today;
+
+    _monthStart = new(baseDate.Year, baseDate.Month, 1);
 
     _monthEnd = new(
       _monthStart.Year,
       _monthStart.Month,
       DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month)
     );
-
     _daysOfCurrentMonth = GetEachDayOfInterval(
       GetExtendedDateAtFirstWeek(_monthStart, WeekStart),
       GetExtendedDateAtLastWeek(_monthEnd, _weekEnd)).ToList();
 
-    CurrentValue = SelectedDate;
 
     if (!_isRangeMode) return;
 
@@ -141,16 +148,32 @@
     _rangeTo = range?.To;
   }
 
-  protected override void OnParametersSet()
+  private string[] GetAvailableMonths()
   {
-    if (SelectedDate is not null && CurrentValue is not null && !Equals(SelectedDate, CurrentValue))
+    List<string> temp = [];
+
+    for (int i = 0; i < 12; i++)
     {
-      CurrentValue = SelectedDate;
+      if (i + 1 >= MinDate.Month && i + 1 <= MaxDate.Month)
+      {
+        temp.Add(DateTimeFormatInfo.CurrentInfo.MonthNames[i]);
+      }
+    }
+    return [.. temp];
+  }
+
+  private int[] GetAvailableYears()
+  {
+    List<int> temp = [];
+    int min = MinDate.Year == DateTime.MinValue.Year ? 1980 : MinDate.Year;
+    int max = MaxDate.Year == DateTime.MaxValue.Year ? _today.Year : MaxDate.Year;
+
+    for (int i = max; i >= min; i--)
+    {
+      temp.Add(i);
     }
 
-    if (CurrentValue is not null) return;
-
-    SelectedDate = default;
+    return [.. temp];
   }
 
   private void OnSelectedDateChange(DateTime day)
@@ -169,16 +192,14 @@
 
   private void HandleSingleDateSelection(DateTime day)
   {
-    if (Equals(SelectedDate, CastToTValue(day)) && Nullable.GetUnderlyingType(typeof(TValue)) != null)
+    if (Equals(CurrentValue, CastToTValue(day)) && Nullable.GetUnderlyingType(typeof(TValue)) != null)
     {
-      SelectedDate = default;
+      CurrentValue = default;
     }
     else
     {
-      SelectedDate = CastToTValue(day);
+      CurrentValue = CastToTValue(day);
     }
-
-    CurrentValue = SelectedDate;
   }
 
   private void HandleDateRangeSelection(DateTime day)
@@ -209,7 +230,6 @@
     {
       _rangeFrom = null;
       _rangeTo = null;
-      SelectedDate = default;
       CurrentValue = default;
       return;
     }
@@ -234,7 +254,6 @@
       range.To = day;
     }
 
-    SelectedDate = (TValue)(object)range;
     CurrentValue = (TValue)(object)range;
   }
 
@@ -244,7 +263,6 @@
     {
       _rangeFrom = null;
       _rangeTo = null;
-      SelectedDate = default;
       CurrentValue = default;
       return;
     }
@@ -270,7 +288,6 @@
       }
     }
 
-    SelectedDate = (TValue)(object)range;
     CurrentValue = (TValue)(object)range;
   }
 

--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -15,7 +15,7 @@
          ])"
   @ref="Element">
 
-  <div class="w-full flex items-center justify-between px-4 py-2 border-b border-border">
+  <div class="w-full flex items-center justify-between px-4 py-2 gap-2 border-b border-border">
     <button
       @onclick="PreviousMonth"
       class="@Tw([
@@ -122,7 +122,7 @@
     _weekEnd = (DayOfWeek)((int)(WeekStart + 6) % 7);
 
     (DateTime? date, _) = CastToDateTime(CurrentValue);
-    if (date.HasValue && date.Value <= DateTime.MinValue)
+    if (date.HasValue && date.Value <= DateTime.MinValue || CurrentValue is null)
     {
       CurrentValue = CastToTValue(_today);
     }
@@ -234,8 +234,6 @@
       return;
     }
 
-    if (day == range.From) return;
-
     if (_rangeFrom.HasValue && _rangeTo.HasValue)
     {
       _rangeFrom = day;
@@ -267,7 +265,7 @@
       return;
     }
 
-    if (!_rangeFrom.HasValue || (day == range.From || day == range.To))
+    if (!_rangeFrom.HasValue || day == range.From || day == range.To)
     {
       _rangeFrom = day;
       range.From = day;

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -41,7 +41,6 @@ public partial class Calendar<TValue> : InputBase<TValue>
         { DayOfWeek.Saturday, "col-start-7" },
     };
 
-    static NullabilityInfoContext _nullabilityInfoContext = new NullabilityInfoContext();
 
     public Calendar()
     {
@@ -159,13 +158,25 @@ public partial class Calendar<TValue> : InputBase<TValue>
             extendedDate = extendedDate.AddDays(7);
         }
 
+        if (extendedDate > DateTime.MaxValue)
+        {
+            extendedDate = DateTime.MaxValue;
+        }
+
         return extendedDate;
     }
 
     private static DateTime GetExtendedDateAtFirstWeek(DateTime day, DayOfWeek firstWeekDay)
     {
         int daysToAdd = (day.DayOfWeek - firstWeekDay + 7) % 7;
-        return day.AddDays(-daysToAdd);
+        DateTime result = day.AddDays(-daysToAdd);
+
+        if (result < DateTime.MinValue)
+        {
+            result = DateTime.MinValue;
+        }
+
+        return result;
     }
 
     private bool CheckPreviousMonth()
@@ -204,25 +215,25 @@ public partial class Calendar<TValue> : InputBase<TValue>
 
     private bool IsDaySelected(DateTime day)
     {
-        (DateTime? from, DateTime? to) = CastToDateTime(SelectedDate);
+        (DateTime? from, DateTime? to) = CastToDateTime(CurrentValue);
         return day == from || day == to;
     }
 
     private bool IsBetweenSelection(DateTime day)
     {
-        (DateTime? from, DateTime? to) = CastToDateTime(SelectedDate);
+        (DateTime? from, DateTime? to) = CastToDateTime(CurrentValue);
         return day > from && day < to;
     }
 
     private bool IsFromDate(DateTime day)
     {
-        (DateTime? from, DateTime? to) = CastToDateTime(SelectedDate);
+        (DateTime? from, DateTime? to) = CastToDateTime(CurrentValue);
         return IsDaySelected(day) && day == from && to is not null && _isRangeMode;
     }
 
     private bool IsToDate(DateTime day)
     {
-        (_, DateTime? to) = CastToDateTime(SelectedDate);
+        (_, DateTime? to) = CastToDateTime(CurrentValue);
         return IsDaySelected(day) && day == to && _isRangeMode;
     }
 }
@@ -236,7 +247,7 @@ public enum CalendarDateRangeBehavior
     KeepFromMoveTo,
 }
 
-public class CalendarDateRange
+public sealed class CalendarDateRange
 {
     public DateTime From { get; set; }
     public DateTime? To { get; set; }

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
 using TailwindMerge;

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -22,18 +22,6 @@ public partial class Calendar<TValue> : InputBase<TValue>
 
     private readonly bool _isRangeMode;
 
-    private static readonly Dictionary<DayOfWeek, string> ColWeekShift = new()
-    {
-        { DayOfWeek.Sunday, "" },
-        { DayOfWeek.Monday, "col-start-2" },
-        { DayOfWeek.Tuesday, "col-start-3" },
-        { DayOfWeek.Wednesday, "col-start-4" },
-        { DayOfWeek.Thursday, "col-start-5" },
-        { DayOfWeek.Friday, "col-start-6" },
-        { DayOfWeek.Saturday, "col-start-7" },
-    };
-
-
     public Calendar()
     {
         Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -11,7 +12,6 @@ namespace Pango.UI.Components;
 public partial class Calendar<TValue> : InputBase<TValue>
 {
     [DisallowNull] public ElementReference? Element { get; protected set; }
-    [Parameter] public InputDateType Type { get; set; } = InputDateType.Date;
     [Parameter] public string ParsingErrorMessage { get; set; } = string.Empty;
 
     [Inject] protected TwMerge TwMerge { get; set; } = null!;
@@ -21,14 +21,15 @@ public partial class Calendar<TValue> : InputBase<TValue>
     /// </summary>
     private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
 
-    private string _typeAttributeValue = null!;
-    private string _format = null!;
-    private string _parsingErrorMessage = null!;
+    // private string _typeAttributeValue = null!;
+    // private string _format = null!;
+    // private string _parsingErrorMessage = null!;
+    private readonly bool _isRangeMode;
 
-    private const string DateFormat = "yyyy-MM-dd"; // Compatible with HTML 'date' inputs
-    private const string DateTimeLocalFormat = "yyyy-MM-ddTHH:mm:ss"; // Compatible with HTML 'datetime-local' inputs
-    private const string MonthFormat = "yyyy-MM"; // Compatible with HTML 'month' inputs
-    private const string TimeFormat = "HH:mm:ss"; // Compatible with HTML 'time' inputs
+    // private const string DateFormat = "yyyy-MM-dd"; // Compatible with HTML 'date' inputs
+    // private const string DateTimeLocalFormat = "yyyy-MM-ddTHH:mm:ss"; // Compatible with HTML 'datetime-local' inputs
+    // private const string MonthFormat = "yyyy-MM"; // Compatible with HTML 'month' inputs
+    // private const string TimeFormat = "HH:mm:ss"; // Compatible with HTML 'time' inputs
 
     private static readonly Dictionary<DayOfWeek, string> ColWeekShift = new()
     {
@@ -41,21 +42,27 @@ public partial class Calendar<TValue> : InputBase<TValue>
         { DayOfWeek.Saturday, "col-start-7" },
     };
 
+    static NullabilityInfoContext _nullabilityInfoContext = new NullabilityInfoContext();
+
     public Calendar()
     {
         Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
 
         if (type != typeof(DateTime) &&
-            type != typeof(DateTimeOffset) &&
+            //type != typeof(DateTimeOffset) &&
             type != typeof(DateOnly) &&
-            type != typeof(TimeOnly) &&
+            //type != typeof(TimeOnly) &&
             type != typeof(CalendarDateRange))
         {
             throw new InvalidOperationException($"Unsupported {GetType()} type param '{type}'.");
         }
+
+        _isRangeMode = type == typeof(CalendarDateRange);
     }
 
-    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result,
+    protected override bool TryParseValueFromString(
+        string? value,
+        [MaybeNullWhen(false)] out TValue result,
         [NotNullWhen(false)] out string? validationErrorMessage)
     {
         if (BindConverter.TryConvertTo(value, CultureInfo.InvariantCulture, out result))
@@ -65,7 +72,7 @@ public partial class Calendar<TValue> : InputBase<TValue>
             return true;
         }
 
-        validationErrorMessage = string.Format(CultureInfo.InvariantCulture, _parsingErrorMessage,
+        validationErrorMessage = string.Format(CultureInfo.InvariantCulture, ParsingErrorMessage,
             DisplayName ?? FieldIdentifier.FieldName);
         return false;
     }
@@ -81,38 +88,50 @@ public partial class Calendar<TValue> : InputBase<TValue>
     private bool IsSameMonth(DateTime day)
         => day.Month == _monthStart.Month;
 
-    private static TValue? CastToTValue(DateTime day)
+    private static TValue? CastToTValue(DateTime from, DateTime? to = null)
     {
         Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
 
         if (type == typeof(DateTime))
         {
-            return (TValue)(object)day;
+            return (TValue)(object)from;
         }
 
         if (type == typeof(DateOnly))
         {
-            return (TValue)(object)DateOnly.FromDateTime(day);
+            return (TValue)(object)DateOnly.FromDateTime(from);
+        }
+
+        if (type == typeof(CalendarDateRange))
+        {
+            CalendarDateRange newDateRange = new() { From = from, To = to };
+            return (TValue)(object)newDateRange;
         }
 
         throw new InvalidOperationException($"Unsupported type param '{type}'.");
     }
 
-    private static DateTime? CastToDateTime(TValue? value)
+    private static (DateTime?, DateTime?) CastToDateTime(TValue? value)
     {
         Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
 
         if (type == typeof(DateTime))
         {
-            return (DateTime?)(object?)value;
+            return ((DateTime?)(object?)value, null);
         }
 
         if (type == typeof(DateOnly))
         {
-            return ((DateOnly?)(object?)value)?.ToDateTime(TimeOnly.MinValue);
+            return (((DateOnly?)(object?)value)?.ToDateTime(TimeOnly.MinValue), null);
         }
 
-        return null;
+        if (type == typeof(CalendarDateRange))
+        {
+            CalendarDateRange? range = (CalendarDateRange?)(object?)value;
+            return (range?.From, range?.To);
+        }
+
+        return (null, null);
     }
 
     private DateTime GetExtendedDateAtLastWeek(DateTime date, DayOfWeek lastWeekDay)
@@ -133,6 +152,73 @@ public partial class Calendar<TValue> : InputBase<TValue>
         int daysToAdd = (day.DayOfWeek - firstWeekDay + 7) % 7;
         return day.AddDays(-daysToAdd);
     }
+
+    private bool CheckPreviousMonth()
+    {
+        DateTime date;
+
+        if (DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month) > MinDate.Day)
+        {
+            date = new(_monthStart.Year, _monthStart.Month, MinDate.Day);
+        }
+        else
+        {
+            date = new(_monthStart.Year, _monthStart.Month, DateTime.DaysInMonth(_monthStart.Year, _monthStart.Month));
+        }
+
+        date = date.AddMonths(-1);
+        return date >= MinDate && _daysOfCurrentMonth.All(d => d != date);
+    }
+
+    private bool CheckNextMonth()
+    {
+        DateTime date;
+
+        if (DateTime.DaysInMonth(_monthEnd.Year, _monthEnd.Month) > MaxDate.Day)
+        {
+            date = new(_monthEnd.Year, _monthEnd.Month, MaxDate.Day);
+        }
+        else
+        {
+            date = new(_monthEnd.Year, _monthEnd.Month, DateTime.DaysInMonth(_monthEnd.Year, _monthEnd.Month));
+        }
+
+        date = date.AddMonths(1);
+        return date <= MaxDate && _daysOfCurrentMonth.All(d => d != date);
+    }
+
+    private bool IsDaySelected(DateTime day)
+    {
+        (DateTime? from, DateTime? to) = CastToDateTime(SelectedDate);
+        return day == from || day == to;
+    }
+
+    private bool IsBetweenSelection(DateTime day)
+    {
+        (DateTime? from, DateTime? to) = CastToDateTime(SelectedDate);
+        return day > from && day < to;
+    }
+
+    private bool IsFromDate(DateTime day)
+    {
+        (DateTime? from, DateTime? to) = CastToDateTime(SelectedDate);
+        return IsDaySelected(day) && day == from && to is not null && _isRangeMode;
+    }
+
+    private bool IsToDate(DateTime day)
+    {
+        (_, DateTime? to) = CastToDateTime(SelectedDate);
+        return IsDaySelected(day) && day == to && _isRangeMode;
+    }
+}
+
+public enum CalendarDateRangeBehavior
+{
+    // Google Flights behavior, each click selects a new range
+    AlwaysSelectNewRange,
+
+    //Shadcn ui / react-day-picker behavior, clicking inside the range only changes the To value
+    KeepFromMoveTo,
 }
 
 public class CalendarDateRange

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -85,6 +85,22 @@ public partial class Calendar<TValue> : InputBase<TValue>
         }
     }
 
+    private int? GetColStart(DayOfWeek dayOfWeek)
+    {
+        int colStart = ((int)dayOfWeek - (int)WeekStart + 7) % 7 + 1;
+        return colStart == 1 ? null : colStart;
+    }
+
+    private string[] GetWeekDaysNames()
+    {
+        string[] dayNames = CultureInfo.CurrentCulture.DateTimeFormat.AbbreviatedDayNames;
+        int startIndex = (int)WeekStart;
+
+        return dayNames.Skip(startIndex)
+            .Concat(dayNames.Take(startIndex))
+            .ToArray();
+    }
+
     private bool IsSameMonth(DateTime day)
         => day.Month == _monthStart.Month;
 

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using TailwindMerge;
+
+namespace Pango.UI.Components;
+
+public partial class Calendar<TValue> : InputBase<TValue>
+{
+    [DisallowNull] public ElementReference? Element { get; protected set; }
+    [Parameter] public InputDateType Type { get; set; } = InputDateType.Date;
+    [Parameter] public string ParsingErrorMessage { get; set; } = string.Empty;
+
+    [Inject] protected TwMerge TwMerge { get; set; } = null!;
+
+    /// <summary>
+    /// Merge Tailwind CSS classes without style conflicts
+    /// </summary>
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+
+    private string _typeAttributeValue = null!;
+    private string _format = null!;
+    private string _parsingErrorMessage = null!;
+
+    private const string DateFormat = "yyyy-MM-dd"; // Compatible with HTML 'date' inputs
+    private const string DateTimeLocalFormat = "yyyy-MM-ddTHH:mm:ss"; // Compatible with HTML 'datetime-local' inputs
+    private const string MonthFormat = "yyyy-MM"; // Compatible with HTML 'month' inputs
+    private const string TimeFormat = "HH:mm:ss"; // Compatible with HTML 'time' inputs
+
+    private static readonly Dictionary<DayOfWeek, string> ColWeekShift = new()
+    {
+        { DayOfWeek.Sunday, "" },
+        { DayOfWeek.Monday, "col-start-2" },
+        { DayOfWeek.Tuesday, "col-start-3" },
+        { DayOfWeek.Wednesday, "col-start-4" },
+        { DayOfWeek.Thursday, "col-start-5" },
+        { DayOfWeek.Friday, "col-start-6" },
+        { DayOfWeek.Saturday, "col-start-7" },
+    };
+
+    public Calendar()
+    {
+        Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+
+        if (type != typeof(DateTime) &&
+            type != typeof(DateTimeOffset) &&
+            type != typeof(DateOnly) &&
+            type != typeof(TimeOnly) &&
+            type != typeof(CalendarDateRange))
+        {
+            throw new InvalidOperationException($"Unsupported {GetType()} type param '{type}'.");
+        }
+    }
+
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TValue result,
+        [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (BindConverter.TryConvertTo(value, CultureInfo.InvariantCulture, out result))
+        {
+            Debug.Assert(result != null);
+            validationErrorMessage = null;
+            return true;
+        }
+
+        validationErrorMessage = string.Format(CultureInfo.InvariantCulture, _parsingErrorMessage,
+            DisplayName ?? FieldIdentifier.FieldName);
+        return false;
+    }
+
+    private static IEnumerable<DateTime> GetEachDayOfInterval(DateTime start, DateTime end)
+    {
+        for (DateTime day = start; day <= end; day = day.AddDays(1))
+        {
+            yield return day;
+        }
+    }
+
+    private bool IsSameMonth(DateTime day)
+        => day.Month == _monthStart.Month;
+
+    private static TValue? CastToTValue(DateTime day)
+    {
+        Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+
+        if (type == typeof(DateTime))
+        {
+            return (TValue)(object)day;
+        }
+
+        if (type == typeof(DateOnly))
+        {
+            return (TValue)(object)DateOnly.FromDateTime(day);
+        }
+
+        throw new InvalidOperationException($"Unsupported type param '{type}'.");
+    }
+
+    private static DateTime? CastToDateTime(TValue? value)
+    {
+        Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
+
+        if (type == typeof(DateTime))
+        {
+            return (DateTime?)(object?)value;
+        }
+
+        if (type == typeof(DateOnly))
+        {
+            return ((DateOnly?)(object?)value)?.ToDateTime(TimeOnly.MinValue);
+        }
+
+        return null;
+    }
+
+    private DateTime GetExtendedDateAtLastWeek(DateTime date, DayOfWeek lastWeekDay)
+    {
+        int daysToAdd = (7 + lastWeekDay - date.DayOfWeek) % 7;
+        DateTime extendedDate = date.AddDays(daysToAdd);
+
+        if (FixedHeight && extendedDate.Month == date.Month)
+        {
+            extendedDate = extendedDate.AddDays(7);
+        }
+
+        return extendedDate;
+    }
+
+    private static DateTime GetExtendedDateAtFirstWeek(DateTime day, DayOfWeek firstWeekDay)
+    {
+        int daysToAdd = (day.DayOfWeek - firstWeekDay + 7) % 7;
+        return day.AddDays(-daysToAdd);
+    }
+}
+
+public class CalendarDateRange
+{
+    public DateTime From { get; set; }
+    public DateTime? To { get; set; }
+}

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -20,15 +20,7 @@ public partial class Calendar<TValue> : InputBase<TValue>
     /// </summary>
     private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
 
-    // private string _typeAttributeValue = null!;
-    // private string _format = null!;
-    // private string _parsingErrorMessage = null!;
     private readonly bool _isRangeMode;
-
-    // private const string DateFormat = "yyyy-MM-dd"; // Compatible with HTML 'date' inputs
-    // private const string DateTimeLocalFormat = "yyyy-MM-ddTHH:mm:ss"; // Compatible with HTML 'datetime-local' inputs
-    // private const string MonthFormat = "yyyy-MM"; // Compatible with HTML 'month' inputs
-    // private const string TimeFormat = "HH:mm:ss"; // Compatible with HTML 'time' inputs
 
     private static readonly Dictionary<DayOfWeek, string> ColWeekShift = new()
     {
@@ -47,9 +39,7 @@ public partial class Calendar<TValue> : InputBase<TValue>
         Type type = Nullable.GetUnderlyingType(typeof(TValue)) ?? typeof(TValue);
 
         if (type != typeof(DateTime) &&
-            //type != typeof(DateTimeOffset) &&
             type != typeof(DateOnly) &&
-            //type != typeof(TimeOnly) &&
             type != typeof(CalendarDateRange))
         {
             throw new InvalidOperationException($"Unsupported {GetType()} type param '{type}'.");

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.js
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.js
@@ -57,7 +57,12 @@ export function ScrollToElement(dialogElement, targetValue) {
     const options = dialogElement.querySelectorAll('[role="option"]');
     const targetOption = Array.from(options).find(opt => opt.textContent.trim() === targetValue);
 
-    if (targetOption) {
-        targetOption.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    }
+    if (!targetOption) return;
+
+    requestAnimationFrame(() => {
+        targetOption.scrollIntoView({
+            block: 'center',
+            behavior: 'auto'
+        });
+    });
 }

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.js
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.js
@@ -1,0 +1,63 @@
+import { computePosition, flip, shift, autoUpdate } from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.4/+esm';
+
+export async function ComputeDialogPosition(
+    anchorElement,
+    dialogElement,
+    placement,
+    callbackInstance,
+    callbackName
+) {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+
+    async function updatePosition() {
+        const {x, y} = await computePosition(anchorElement, dialogElement, {
+            placement,
+            middleware: [flip(), shift()],
+        });
+
+        Object.assign(dialogElement.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+        });
+    }
+
+    const positionCleaner = autoUpdate(
+        anchorElement,
+        dialogElement,
+        updatePosition,
+    )
+
+    if (!dialogElement.open && !!dialogElement.showModal) {
+        dialogElement.showModal();
+
+        window.scrollTo(scrollX, scrollY);
+
+        dialogElement.addEventListener('click', () => {
+            dialogElement.close();
+        });
+
+        dialogElement.addEventListener('close', () => {
+            callbackInstance.invokeMethodAsync(callbackName)
+        });
+    }
+
+    return {
+        CleanUpPosition: () => {
+            if (dialogElement.open && !!dialogElement.close) {
+                dialogElement.close();
+            }
+
+            positionCleaner()
+        }
+    };
+}
+
+export function ScrollToElement(dialogElement, targetValue) {
+    const options = dialogElement.querySelectorAll('[role="option"]');
+    const targetOption = Array.from(options).find(opt => opt.textContent.trim() === targetValue);
+
+    if (targetOption) {
+        targetOption.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+}

--- a/src/Pango.UI/Components/Calendar/CalendarMonthSelector.razor
+++ b/src/Pango.UI/Components/Calendar/CalendarMonthSelector.razor
@@ -1,3 +1,4 @@
+@using System.Globalization
 @namespace Pango.UI.Components
 
 @inject IJSRuntime JS
@@ -25,15 +26,14 @@
            "relative z-50 max-h min-w-[8rem] rounded-md border shadow-md",
          ])"
   @ref="_contentRef">
-  @foreach(var item in _availableMonths)
+  @foreach (string name in AvailableMonths)
   {
     <div
       role="option"
-      @onclick="() => OnMonthSelect(item.Key)"
-      tabindex="@(_focusedIndex == item.Key ? 0 : -1)"
+      @onclick="() => OnMonthSelect(name)"
       class="cursor-pointer hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground &_svg:not([class*='text-'])]:text-muted-foreground relative flex justify-between w-full items-center gap-2 rounded-sm py-1.5 px-2 text-sm outline-hidden select-none data-[disabled]:hover:bg-transparent data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2">
-      <span>@(item.Value)</span>
-      @if (SelectedMonth - 1 == item.Key)
+      <span>@(name)</span>
+      @if (DateTimeFormatInfo.CurrentInfo.GetMonthName(SelectedMonth).Equals(name, StringComparison.CurrentCultureIgnoreCase))
       {
         <i class="ph ph-check"></i>
       }
@@ -54,11 +54,11 @@
   /// Merge Tailwind CSS classes without style conflicts
   /// </summary>
   private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+
   private bool _open;
   private ElementReference _triggerRef;
   private ElementReference _contentRef;
   private int _focusedIndex;
-  private Dictionary<int, string> _availableMonths = new();
 
   private IJSObjectReference? _jsDropdownRender;
   private IJSObjectReference? _jsDropdownCleaner;
@@ -67,13 +67,6 @@
   protected override void OnInitialized()
   {
     base.OnInitialized();
-    for (int i = 0; i < AvailableMonths.Length; i++)
-    {
-      _availableMonths.Add(i, AvailableMonths[i]);
-    }
-
-    _availableMonths.Remove(AvailableMonths.Length - 1);
-
     _csSelectRef = DotNetObjectReference.Create(this);
   }
 
@@ -117,9 +110,14 @@
     }
   }
 
-  private async Task OnMonthSelect(int month)
+  private async Task OnMonthSelect(string month)
   {
-    await OnMonthChange.InvokeAsync(month + 1);
+    await OnMonthChange.InvokeAsync(DateTime.ParseExact(
+      month,
+      new[] { "MMM", "MMMM" },
+      CultureInfo.InvariantCulture,
+      DateTimeStyles.None
+    ).Month);
   }
 
   private async Task HandleKeyDown(string key)
@@ -141,4 +139,5 @@
         break;
     }
   }
+
 }

--- a/src/Pango.UI/Components/Calendar/CalendarMonthSelector.razor
+++ b/src/Pango.UI/Components/Calendar/CalendarMonthSelector.razor
@@ -1,0 +1,144 @@
+@namespace Pango.UI.Components
+
+@inject IJSRuntime JS
+
+<button
+  type="button"
+  role="combobox"
+  @onclick="OpenMonthSelection"
+  class="transition-colors duration-200 cursor-pointer flex flex-row gap-2 items-center px-2 py-1 border border-border rounded-md hover:bg-accent"
+  @ref="_triggerRef">
+  <span>@Label</span>
+  <i class="ph ph-caret-down opacity-50"></i>
+</button>
+<dialog
+  @onkeydown="(args) => HandleKeyDown(args.Key)"
+  data-state="@(_open ? "open" : "closed")"
+  class="@Tw([
+           "bg-popover [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-accent " +
+           "[&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-primary " +
+           "[&::-webkit-scrollbar-thumb:hover]:bg-primary/70 overflow-y-auto max-h-96 text-popover-foreground p-1 " +
+           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 " +
+           "data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 " +
+           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 " +
+           "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 " +
+           "relative z-50 max-h min-w-[8rem] rounded-md border shadow-md",
+         ])"
+  @ref="_contentRef">
+  @foreach(var item in _availableMonths)
+  {
+    <div
+      role="option"
+      @onclick="() => OnMonthSelect(item.Key)"
+      tabindex="@(_focusedIndex == item.Key ? 0 : -1)"
+      class="cursor-pointer hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground &_svg:not([class*='text-'])]:text-muted-foreground relative flex justify-between w-full items-center gap-2 rounded-sm py-1.5 px-2 text-sm outline-hidden select-none data-[disabled]:hover:bg-transparent data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2">
+      <span>@(item.Value)</span>
+      @if (SelectedMonth - 1 == item.Key)
+      {
+        <i class="ph ph-check"></i>
+      }
+    </div>
+  }
+</dialog>
+
+@code {
+
+  [Parameter] public string Label { get; set; } = string.Empty;
+  [Parameter] public string[] AvailableMonths { get; set; } = [];
+  [Parameter] public int SelectedMonth { get; set; }
+  [Parameter] public EventCallback<int> OnMonthChange { get; set; }
+
+  [Inject] protected TwMerge TwMerge { get; set; } = null!;
+
+  /// <summary>
+  /// Merge Tailwind CSS classes without style conflicts
+  /// </summary>
+  private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+  private bool _open;
+  private ElementReference _triggerRef;
+  private ElementReference _contentRef;
+  private int _focusedIndex;
+  private Dictionary<int, string> _availableMonths = new();
+
+  private IJSObjectReference? _jsDropdownRender;
+  private IJSObjectReference? _jsDropdownCleaner;
+  private DotNetObjectReference<CalendarMonthSelector>? _csSelectRef;
+
+  protected override void OnInitialized()
+  {
+    base.OnInitialized();
+    for (int i = 0; i < AvailableMonths.Length; i++)
+    {
+      _availableMonths.Add(i, AvailableMonths[i]);
+    }
+
+    _availableMonths.Remove(AvailableMonths.Length - 1);
+
+    _csSelectRef = DotNetObjectReference.Create(this);
+  }
+
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    if (firstRender)
+    {
+      _jsDropdownRender = await JS.InvokeAsync<IJSObjectReference>(
+        "import",
+        "./Components/Calendar/Calendar.razor.js"
+      );
+    }
+
+    await base.OnAfterRenderAsync(firstRender);
+  }
+
+  public async Task OpenMonthSelection()
+  {
+    _open = true;
+    _focusedIndex = 0;
+
+    if (_jsDropdownRender is not null)
+    {
+      _jsDropdownCleaner = await _jsDropdownRender.InvokeAsync<IJSObjectReference>("ComputeDialogPosition", _triggerRef,
+        _contentRef,
+        "bottom-center",
+        _csSelectRef,
+        nameof(CloseMonthSelection)
+      );
+    }
+  }
+
+  [JSInvokable]
+  public async Task CloseMonthSelection()
+  {
+    _open = false;
+
+    if (_jsDropdownCleaner is not null)
+    {
+      await _jsDropdownCleaner.InvokeVoidAsync("CleanUpPosition");
+    }
+  }
+
+  private async Task OnMonthSelect(int month)
+  {
+    await OnMonthChange.InvokeAsync(month + 1);
+  }
+
+  private async Task HandleKeyDown(string key)
+  {
+    if (!_open) return;
+
+    switch (key)
+    {
+      case "ArrowDown":
+        if (_focusedIndex + 1 > AvailableMonths.Length - 1) return;
+        _focusedIndex++;
+        break;
+      case "ArrowUp":
+        if (_focusedIndex - 1 < 0) return;
+        _focusedIndex--;
+        break;
+      case "Escape":
+        await CloseMonthSelection();
+        break;
+    }
+  }
+}

--- a/src/Pango.UI/Components/Calendar/CalendarYearSelector.razor
+++ b/src/Pango.UI/Components/Calendar/CalendarYearSelector.razor
@@ -3,6 +3,7 @@
 @inject IJSRuntime JS
 
 <button
+  type="button"
   role="combobox"
   @onclick="OpenYearSelection"
   class="transition-colors duration-200 cursor-pointer flex flex-row gap-2 items-center px-2 py-1 border border-border rounded-md hover:bg-accent"

--- a/src/Pango.UI/Components/Calendar/CalendarYearSelector.razor
+++ b/src/Pango.UI/Components/Calendar/CalendarYearSelector.razor
@@ -1,0 +1,138 @@
+@namespace Pango.UI.Components
+
+@inject IJSRuntime JS
+
+<button
+  role="combobox"
+  @onclick="OpenYearSelection"
+  class="transition-colors duration-200 cursor-pointer flex flex-row gap-2 items-center px-2 py-1 border border-border rounded-md hover:bg-accent"
+  @ref="_triggerRef">
+  <span>@Label</span>
+  <i class="ph ph-caret-down opacity-50"></i>
+</button>
+<dialog
+  @onkeydown="(args) => HandleKeyDown(args.Key)"
+  data-state="@(_open ? "open" : "closed")"
+  class="@Tw([
+           "bg-popover [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-accent " +
+           "[&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-primary " +
+           "[&::-webkit-scrollbar-thumb:hover]:bg-primary/70 overflow-y-auto max-h-96 text-popover-foreground p-1 " +
+           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 " +
+           "data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 " +
+           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 " +
+           "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 " +
+           "relative z-50 max-h min-w-[8rem] rounded-md border shadow-md",
+         ])"
+  @ref="_contentRef">
+  @foreach(var (year, i) in AvailableYears.Select((y, i) => (y, i)))
+  {
+    <div
+      role="option"
+      @onclick="() => OnYearSelect(year)"
+      tabindex="@(_focusedIndex == i ? 0 : -1)"
+      class="cursor-pointer hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground &_svg:not([class*='text-'])]:text-muted-foreground relative flex justify-between w-full items-center gap-2 rounded-sm py-1.5 px-2 text-sm outline-hidden select-none data-[disabled]:hover:bg-transparent data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2">
+      <span>@year</span>
+      @if (SelectedYear == year)
+      {
+        <i class="ph ph-check"></i>
+      }
+    </div>
+  }
+</dialog>
+
+@code {
+
+  [Parameter] public string Label { get; set; } = string.Empty;
+  [Parameter] public int[] AvailableYears { get; set; } = [];
+  [Parameter] public int SelectedYear { get; set; }
+  [Parameter] public EventCallback<int> OnYearChange { get; set; }
+
+  [Inject] protected TwMerge TwMerge { get; set; } = null!;
+
+  /// <summary>
+  /// Merge Tailwind CSS classes without style conflicts
+  /// </summary>
+  private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+  private bool _open;
+  private ElementReference _triggerRef;
+  private ElementReference _contentRef;
+  private int _focusedIndex;
+
+  private IJSObjectReference? _jsDropdownRender;
+  private IJSObjectReference? _jsDropdownCleaner;
+  private DotNetObjectReference<CalendarYearSelector>? _csSelectRef;
+
+  protected override void OnInitialized()
+  {
+    base.OnInitialized();
+    _csSelectRef = DotNetObjectReference.Create(this);
+  }
+
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    if (firstRender)
+    {
+      _jsDropdownRender = await JS.InvokeAsync<IJSObjectReference>(
+        "import",
+        "./Components/Calendar/Calendar.razor.js"
+      );
+    }
+
+    await base.OnAfterRenderAsync(firstRender);
+  }
+
+  public async Task OpenYearSelection()
+  {
+    _open = true;
+    _focusedIndex = 0;
+
+    if (_jsDropdownRender is not null)
+    {
+      _jsDropdownCleaner = await _jsDropdownRender.InvokeAsync<IJSObjectReference>("ComputeDialogPosition", _triggerRef,
+        _contentRef,
+        "bottom-center",
+        _csSelectRef,
+        nameof(CloseYearSelection)
+      );
+
+      await _jsDropdownRender.InvokeVoidAsync("ScrollToElement", _contentRef, SelectedYear.ToString());
+    }
+
+  }
+
+  [JSInvokable]
+  public async Task CloseYearSelection()
+  {
+    _open = false;
+
+    if (_jsDropdownCleaner is not null)
+    {
+      await _jsDropdownCleaner.InvokeVoidAsync("CleanUpPosition");
+    }
+  }
+
+  private async Task OnYearSelect(int month)
+  {
+    await OnYearChange.InvokeAsync(month);
+  }
+
+  private async Task HandleKeyDown(string key)
+  {
+    if (!_open) return;
+
+    switch (key)
+    {
+      case "ArrowDown":
+        if (_focusedIndex + 1 > AvailableYears.Length - 1) return;
+        _focusedIndex++;
+        break;
+      case "ArrowUp":
+        if (_focusedIndex - 1 < 0) return;
+        _focusedIndex--;
+        break;
+      case "Escape":
+        await CloseYearSelection();
+        break;
+    }
+  }
+}

--- a/src/Pango.UI/Docs/Components/Calendar/Calendar.mdx
+++ b/src/Pango.UI/Docs/Components/Calendar/Calendar.mdx
@@ -1,0 +1,66 @@
+```json :pango-ui-document-metadata
+{
+  "Title": "Calendar",
+  "Description": "A calendar component that let the user select a date or a range of dates.",
+  "Featured": true,
+  "IsComponent": true,
+  "Tags": ["UI", "Interactive"],
+  "Sections": [
+    { "Title": "Properties" },
+    { "Title": "Installation" },
+    {
+      "Title": "Examples",
+      "Sections": [
+        { "Id": "range", "Title": "Date Range" },
+        { "Id": "usage", "Title": "Usage" }
+      ]
+    }
+  ]
+}
+```
+# Calendar
+
+A calendar component that let the user select a date or a range of dates.
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesCalendarDefault.razor" >
+    <ExamplesCalendarDefault />
+</ComponentPreview>
+
+## Properties
+
+- **Behavior:** Defines the **date range** behavior *(you must pass the custom type `CalendarDateRange` to use date range)* 
+the default behavior *(`CalendarDateRangeBehavior.KeepFromMoveTo`)* is based on the [shadcn/ui - react-day-picker](https://ui.shadcn.com/docs/components/radix/calendar#range-calendar)
+which keeps the range selected and changes the `From` or `To` values. There is also the `CalendarDateRangeBehavior.AlwaysSelectNewRange`
+which is based on the [Google Flights](https://www.google.com/travel/flights) behavior that selects a new range on every day selected.
+- **FixedHeight:** The default is `true`. Fixed height prevents the calendar height to change and shift your UI, or even
+in date picker components, a height shift may cause a misclick.
+- **WithMonthAndYearSelection:** Default is `false`, why you ask? Because yes. This property enables the month and year
+selection so the user doesn't have to click on the arrows 12 times to switch years.
+- **WeekStart:** Default is `DayOfWeek.Sunday`. This property let you choose which day of the week will the calendar start,
+you can even start you calendar at thursday for whatever reason.
+- **MinDate:** Default is `DateTime.MinValue` this property disables all days, months and years before it.
+- **MaxDate:** I think you already know, but the default is `DateTime.MaxValue`. Now, can you take a wild guess on what this 
+not self-explanatory property does? You are absolutely right! It disables the days, months and years after it.
+- **Required:** This is an important property if you are using range because the default behavior is to unselect the selected
+day if you click it again, for primitive and supported types `DateTime` and `DateOnly` the requirement of the component can be
+identified by the `TValue`, if you pass `TValue="DateTime?"` it means that it is not required because you are accepting a null
+value, but if you pass `TValue="DateTime"` this means the date is required because your type is not nullable. Now that we are
+on the same page, .NET is not able to recognize nullability on classes only in primitive types, that is why if you need 
+a range to be required set this property to true yeah? Keep it up baby!
+## Installation
+
+<Code Language="fish" class="py-2">dotnet pango add calendar</Code>
+
+## Examples
+
+### Date Range
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesCalendarRange.razor" >
+    <ExamplesCalendarRange />
+</ComponentPreview>
+
+### Usage
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesCalendarEditForm.razor" >
+    <ExamplesCalendarEditForm />
+</ComponentPreview>

--- a/src/Pango.UI/Docs/Components/Calendar/Examples/ExamplesCalendarDefault.razor
+++ b/src/Pango.UI/Docs/Components/Calendar/Examples/ExamplesCalendarDefault.razor
@@ -1,0 +1,14 @@
+<Calendar TValue="DateTime" @bind-Value="_date" />
+
+<span class="px-3 rounded-md border border-primary text-primary py-1.5">@(_date)</span>
+
+<Calendar TValue="DateOnly?" WithMonthAndYearSelection="true" @bind-Value="_dateOnly" />
+
+<span class="px-3 rounded-md border border-primary text-primary py-1.5">@(_dateOnly)</span>
+
+@code {
+
+  DateTime _date = new(2004, 3, 17);
+  DateOnly? _dateOnly;
+
+}

--- a/src/Pango.UI/Docs/Components/Calendar/Examples/ExamplesCalendarEditForm.razor
+++ b/src/Pango.UI/Docs/Components/Calendar/Examples/ExamplesCalendarEditForm.razor
@@ -1,0 +1,52 @@
+@using System.ComponentModel.DataAnnotations
+
+<div class="flex flex-col gap-6 items-center">
+  <EditForm Model="@this" FormName="birthday-example-form" Enhance OnValidSubmit="@HandleSubmit" class="flex flex-col gap-6">
+    <DataAnnotationsValidator/>
+    <div class="flex flex-col gap-2">
+      <label class="font-semibold">Insert your next birthday</label>
+      <Calendar TValue="DateOnly" @bind-Value="SelectedDay" WithMonthAndYearSelection="true"/>
+    </div>
+    <ValidationMessage class="text-sm text-destructive" For="@(() => SelectedDay)"/>
+    <Button type="submit">
+      Submit
+    </Button>
+  </EditForm>
+  @if (_birthday != DateOnly.MinValue)
+  {
+    <Alert Variant="@(Alert.Variants.Sucess)" OnDismiss="@(() => _birthday = DateOnly.MinValue)">
+      <AlertSide>
+        <i class="ph ph-check text-lg"></i>
+      </AlertSide>
+      <AlertTitle>Success</AlertTitle>
+      <AlertDescription>
+        <div class="flex flex-col gap-2">
+          <span>Your next birthday is: <strong class="font-medium">@_birthday</strong></span>
+
+          @if (_today == _birthday)
+          {
+            <span>🎉🥳<strong>Happy Birthday!!!</strong>🥳🎉</span>
+          }
+        </div>
+      </AlertDescription>
+    </Alert>
+  }
+</div>
+
+@code {
+  DateOnly _today = DateOnly.FromDateTime(DateTime.Today);
+
+  [SupplyParameterFromForm]
+  [Display(Name = "Birth Day")]
+  [Required(ErrorMessage = "Please insert your birth day.")]
+  public DateOnly SelectedDay { get; set; }
+
+  DateOnly _birthday;
+
+
+  private void HandleSubmit()
+  {
+    _birthday = SelectedDay;
+  }
+
+}

--- a/src/Pango.UI/Docs/Components/Calendar/Examples/ExamplesCalendarRange.razor
+++ b/src/Pango.UI/Docs/Components/Calendar/Examples/ExamplesCalendarRange.razor
@@ -1,0 +1,20 @@
+<Calendar TValue="CalendarDateRange" Required="true" @bind-Value="_range" />
+
+<span class="px-3 rounded-md border border-primary text-primary py-1.5">
+  <span>From: @(_range.From)</span>
+  <span>To: @(_range.To)</span>
+</span>
+
+<Calendar TValue="CalendarDateRange" Behavior="CalendarDateRangeBehavior.AlwaysSelectNewRange" @bind-Value="_range2" />
+
+<span class="px-3 rounded-md border border-primary text-primary py-1.5">
+  <span>From: @(_range2?.From)</span>
+  <span>To: @(_range2?.To)</span>
+</span>
+
+@code {
+
+  CalendarDateRange _range = new() {From = new (2004, 3, 17), To = new(2004, 3, 22)};
+  CalendarDateRange? _range2;
+
+}

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -50,6 +50,7 @@
     new("Avatar", "./docs/avatar"),
     new("Badge", "./docs/badge"),
     new("Button", "./docs/button"),
+    new("Calendar", "./docs/calendar"),
     new("Checkbox", "./docs/checkbox"),
     new("CheckboxGroup", "./docs/checkbox-group"),
     new("Code", "./docs/code"),


### PR DESCRIPTION
# Functionalities
- **Date Range:** Able to select a range of dates with default behavior `CalendarDateRangeBehavior.KeepFromMoveTo` based on the [shadcn/ui - react-day-picker](https://ui.shadcn.com/docs/components/radix/calendar#range-calendar) and with other option based on [Google Flights](https://www.google.com/travel/flights) which always selects a new range of dates.
- **Month and Year selection:** the `WithMonthAndYearSelection` option enables a select component for the month and year so the user can select a month and year easier and doesn't have to break his mouse from clicking on the arrows.
- **Fixed Height:** The default is true, a fixed height prevents unwanted shift on the UI and on components that put the calendar in a pop up, it prevents the pop up to change position and may cause a mis-click.
- **MinDate and MaxDate:** Limit the range of dates that can be selected.
- **Required:** This parameter must be used if you don't want the `CalendarDateRange` to be null, for the primitive and supported types `DateTime` and `DateOnly` the requirement of the component can be identified through the `TValue` type param. If you pass a `TValue="DateTime?"` it means you are accepting a null value, therefore this value is not required, but with classes .NET can not identify nullability when comparing to a generic type, it only work with primitives, so in order to use **required date range behavior** this parameter must be set to true.
- **WeekStart:** You can start your week on whatever day of the week, even Wednesday for whatever reason, the default is Sunday
 
![HappyCattoGIF](https://github.com/user-attachments/assets/d10e05f6-d9da-4694-8ea2-2d3e7a1c94e6)

