### PR TITLE
feat: adding date picker component

### DIFF
--- a/src/Pango.UI/Components/Calendar/Calendar.razor
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor
@@ -17,6 +17,8 @@
 
   <div class="w-full flex items-center justify-between px-4 py-2 gap-2 border-b border-border">
     <button
+      @onclick:stopPropagation
+      @onclick:preventDefault
       @onclick="PreviousMonth"
       class="@Tw([
                "cursor-pointer transition-colors duration-200 size-7 rounded-md bg-transparent hover:bg-accent hover:text-foreground",
@@ -44,6 +46,8 @@
     }
 
     <button
+      @onclick:stopPropagation
+      @onclick:preventDefault
       @onclick="NextMonth"
       class="@Tw([
                "cursor-pointer transition-colors duration-200 size-7 rounded-md bg-transparent hover:bg-accent hover:text-foreground",
@@ -62,13 +66,14 @@
     {
       <button
         type="button"
+        role="button"
         @onclick:preventDefault
         @onclick="() => OnSelectedDateChange(day)"
         @disabled="@(day <= MinDate || day >= MaxDate)"
         @aria-disabled="@(day <= MinDate || day >= MaxDate)"
         @data-disabled="@(day <= MinDate || day >= MaxDate ? "" : null)"
         class="@Tw([
-                 "transition-colors cursor-pointer duration-200 size-7 text-sm text-foreground/20 rounded-sm hover:bg-accent hover:text-foreground",
+                 "transition-colors cursor-pointer duration-200 mx-1 size-7 text-sm text-foreground/20 rounded-sm hover:bg-accent hover:text-foreground",
                  day == _today ? "bg-accent/50" : null,
                  IsSameMonth(day) && day > MinDate && day < MaxDate ? "text-foreground/80" : null,
                  day <= MinDate || day >= MaxDate ? "hover:bg-transparent hover:text-muted cursor-not-allowed" : null,
@@ -92,6 +97,7 @@
   private static readonly DateTime _today = DateTime.Now.Date;
 
   [Parameter] public CalendarDateRangeBehavior Behavior { get; set; } = CalendarDateRangeBehavior.KeepFromMoveTo;
+  [Parameter] public bool SelectTodayByDefault { get; set; }
   [Parameter] public bool FixedHeight { get; set; } = true;
   [Parameter] public bool WithMonthAndYearSelection { get; set; }
 
@@ -108,8 +114,6 @@
   private DayOfWeek _weekEnd;
   private DateTime _monthStart;
   private DateTime _monthEnd;
-  private DateTime? _rangeFrom;
-  private DateTime? _rangeTo;
 
   private List<DateTime> _daysOfCurrentMonth = [];
 
@@ -120,7 +124,8 @@
     _weekEnd = (DayOfWeek)((int)(WeekStart + 6) % 7);
 
     (DateTime? date, _) = CastToDateTime(CurrentValue);
-    if (date.HasValue && date.Value <= DateTime.MinValue || CurrentValue is null)
+
+    if ((date.HasValue && date.Value <= DateTime.MinValue || CurrentValue is null) && SelectTodayByDefault)
     {
       CurrentValue = CastToTValue(_today);
     }
@@ -142,8 +147,6 @@
     if (!_isRangeMode) return;
 
     CalendarDateRange? range = (CalendarDateRange?)(object?)CurrentValue;
-    _rangeFrom = range?.From;
-    _rangeTo = range?.To;
   }
 
   private string[] GetAvailableMonths()
@@ -224,29 +227,23 @@
 
   private void HandleNewRangeBehavior(DateTime day, CalendarDateRange range)
   {
-    if (day == range.From && _rangeTo is null && !Required)
+    if (day == range.From && range.To is null && !Required)
     {
-      _rangeFrom = null;
-      _rangeTo = null;
       CurrentValue = default;
       return;
     }
 
-    if (_rangeFrom.HasValue && _rangeTo.HasValue)
+    if (range.To.HasValue)
     {
-      _rangeFrom = day;
       range.From = day;
-      _rangeTo = null;
       range.To = null;
     }
-    else if (!_rangeFrom.HasValue || day < _rangeFrom.Value)
+    else if (day < range.From || range.From is null)
     {
-      _rangeFrom = day;
       range.From = day;
     }
     else
     {
-      _rangeTo = day;
       range.To = day;
     }
 
@@ -255,31 +252,25 @@
 
   private void HandleSameRangeBehavior(DateTime day, CalendarDateRange range)
   {
-    if (day == _rangeFrom && _rangeTo is null && !Required)
+    if (day == range.From && range.To is null && !Required)
     {
-      _rangeFrom = null;
-      _rangeTo = null;
       CurrentValue = default;
       return;
     }
 
-    if (!_rangeFrom.HasValue || day == range.From || day == range.To)
+    if (range.From is null || day == range.From || day == range.To)
     {
-      _rangeFrom = day;
       range.From = day;
-      _rangeTo = null;
       range.To = null;
     }
     else
     {
-      if (day < _rangeFrom)
+      if (day < range.From)
       {
-        _rangeFrom = day;
         range.From = day;
       }
       else
       {
-        _rangeTo = day;
         range.To = day;
       }
     }

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.cs
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.cs
@@ -227,6 +227,6 @@ public enum CalendarDateRangeBehavior
 
 public sealed class CalendarDateRange
 {
-    public DateTime From { get; set; }
+    public DateTime? From { get; set; }
     public DateTime? To { get; set; }
 }

--- a/src/Pango.UI/Components/Calendar/Calendar.razor.js
+++ b/src/Pango.UI/Components/Calendar/Calendar.razor.js
@@ -1,4 +1,4 @@
-import { computePosition, flip, shift, autoUpdate } from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.4/+esm';
+import { computePosition, flip, shift, autoUpdate, offset } from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.4/+esm';
 
 export async function ComputeDialogPosition(
     anchorElement,
@@ -13,7 +13,7 @@ export async function ComputeDialogPosition(
     async function updatePosition() {
         const {x, y} = await computePosition(anchorElement, dialogElement, {
             placement,
-            middleware: [flip(), shift()],
+            middleware: [flip(), shift(), offset(5)],
         });
 
         Object.assign(dialogElement.style, {
@@ -54,6 +54,8 @@ export async function ComputeDialogPosition(
 }
 
 export function ScrollToElement(dialogElement, targetValue) {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
     const options = dialogElement.querySelectorAll('[role="option"]');
     const targetOption = Array.from(options).find(opt => opt.textContent.trim() === targetValue);
 
@@ -61,8 +63,10 @@ export function ScrollToElement(dialogElement, targetValue) {
 
     requestAnimationFrame(() => {
         targetOption.scrollIntoView({
-            block: 'center',
-            behavior: 'auto'
+            block: 'nearest',
+            behavior: 'contain'
         });
+        window.scrollTo(scrollX, scrollY);
     });
+
 }

--- a/src/Pango.UI/Components/Calendar/CalendarMonthSelector.razor
+++ b/src/Pango.UI/Components/Calendar/CalendarMonthSelector.razor
@@ -18,7 +18,7 @@
   class="@Tw([
            "bg-popover [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-accent " +
            "[&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-primary " +
-           "[&::-webkit-scrollbar-thumb:hover]:bg-primary/70 overflow-y-auto max-h-96 text-popover-foreground p-1 " +
+           "[&::-webkit-scrollbar-thumb:hover]:bg-primary/70 text-popover-foreground p-1 " +
            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 " +
            "data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 " +
            "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 " +

--- a/src/Pango.UI/Components/Calendar/CalendarYearSelector.razor
+++ b/src/Pango.UI/Components/Calendar/CalendarYearSelector.razor
@@ -15,7 +15,7 @@
   @onkeydown="(args) => HandleKeyDown(args.Key)"
   data-state="@(_open ? "open" : "closed")"
   class="@Tw([
-           "bg-popover [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-accent " +
+           "bg-popover overscroll-contain [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-accent " +
            "[&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-primary " +
            "[&::-webkit-scrollbar-thumb:hover]:bg-primary/70 overflow-y-auto max-h-96 text-popover-foreground p-1 " +
            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 " +
@@ -30,7 +30,6 @@
     <div
       role="option"
       @onclick="() => OnYearSelect(year)"
-      tabindex="@(_focusedIndex == i ? 0 : -1)"
       class="cursor-pointer hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground &_svg:not([class*='text-'])]:text-muted-foreground relative flex justify-between w-full items-center gap-2 rounded-sm py-1.5 px-2 text-sm outline-hidden select-none data-[disabled]:hover:bg-transparent data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2">
       <span>@year</span>
       @if (SelectedYear == year)

--- a/src/Pango.UI/Components/DatePicker/DatePicker.razor
+++ b/src/Pango.UI/Components/DatePicker/DatePicker.razor
@@ -1,0 +1,200 @@
+@namespace Pango.UI.Components
+
+@inject IJSRuntime JS
+
+@using System.Linq.Expressions
+@typeparam TValue
+
+<button
+  @attributes="AdditionalAttributes"
+  type="button"
+  role="button"
+  @onclick:stopPropagation
+  @onclick:preventDefault
+  @onclick="OpenCalendar"
+  disabled="@(Disabled)"
+  aria-disabled="@(Disabled)"
+  data-disabled="@(Disabled)"
+  data-size="@(Size.ToString().ToLower())"
+  class="@Tw([
+           "flex flex-row gap-2 justify-between items-center whitespace-nowrap overflow-hidden transition-colors duration-200 cursor-pointer px-3 py-2 border border-border rounded-md data-[size=default]:h-9 data-[size=sm]:h-8 hover:bg-accent has-[button:hover]:bg-transparent",
+           Disabled ? "opacity-50 cursor-not-allowed hover:bg-transparent" : null,
+           AdditionalAttributes?.GetValueOrDefault("class")?.ToString()
+         ])"
+  @ref="_datePickerTriggerRef">
+
+  @switch (Value)
+  {
+    case DateTime date when date > DateTime.MinValue:
+      <span class="truncate">@date.ToString(DateFormat)</span>
+      break;
+    case DateOnly dateOnly when dateOnly > DateOnly.MinValue:
+      <span class="truncate">@dateOnly.ToString(DateFormat)</span>
+      break;
+    case CalendarDateRange range when range.From > DateTime.MinValue:
+      <span class="truncate">
+          @range.From?.ToString(DateFormat)
+        @(range.To is not null ? " - " : null)
+        @range.To?.ToString(DateFormat)
+        </span>
+      break;
+    default:
+      <span class="opacity-50 truncate">@_placeholder</span>
+      break;
+  }
+
+  @if (CleanSelectedDateButton && !Equals(Value, default(TValue)))
+  {
+    <button
+      type="button"
+      role="button"
+      class="transition-colors duration-200 cursor-pointer rounded-md size-6 hover:bg-accent"
+      @onclick:stopPropagation
+      @onclick="CleanValue">
+      <i class="ph ph-x"></i>
+    </button>
+  }
+  else
+  {
+    <i class="shrink-0 ph ph-caret-down"></i>
+  }
+</button>
+
+<dialog
+  @ref="_datePickerContentRef"
+  disabled="@(Disabled)"
+  aria-disabled="@(Disabled)"
+  data-disabled="@(Disabled)"
+  data-state="@(_open ? "open" : "closed")"
+  class="@Tw([
+           "bg-popover w-fit h-fit [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-accent " +
+           "[&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-primary " +
+           "[&::-webkit-scrollbar-thumb:hover]:bg-primary/70 overflow-y-auto max-h-96 text-popover-foreground " +
+           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 " +
+           "data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 " +
+           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 " +
+           "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 " +
+           "relative z-50 max-h min-w-[8rem] rounded-md shadow-md",
+         ])">
+  <Calendar
+    TValue="TValue?"
+    Value="Value"
+    ValueChanged="OnValueChange"
+    ValueExpression="ValueExpression"
+    WithMonthAndYearSelection="WithMonthAndYearSelection"
+    Behavior="Behavior"
+    MinDate="MinDate"
+    MaxDate="MaxDate"
+    Required="Required"
+    FixedHeight="FixedHeight"
+    WeekStart="WeekStart"/>
+</dialog>
+
+@code {
+
+  [Parameter] public Sizes Size { get; set; } = Sizes.Default;
+  [Parameter] public bool CleanSelectedDateButton { get; set; } = true;
+  [Parameter] public string DateFormat { get; set; } = string.Empty;
+  [Parameter] public bool Disabled { get; set; }
+
+  [Parameter] public TValue? Value { get; set; }
+  [Parameter] public EventCallback<TValue>? ValueChanged { get; set; }
+  [Parameter] public Expression<Func<TValue?>>? ValueExpression { get; set; }
+
+  private object? _placeholder;
+  private IJSObjectReference? _jsDropdownRender;
+  private IJSObjectReference? _jsDropdownCleaner;
+  private DotNetObjectReference<DatePicker<TValue>>? _csSelectRef;
+  private ElementReference? _datePickerTriggerRef;
+  private ElementReference? _datePickerContentRef;
+
+  private bool _open;
+
+  protected override void OnInitialized()
+  {
+    base.OnInitialized();
+    _csSelectRef = DotNetObjectReference.Create(this);
+    _placeholder = AdditionalAttributes?.GetValueOrDefault("placeholder") ?? "Select a date";
+    if (string.IsNullOrWhiteSpace(DateFormat))
+    {
+      DateFormat = "dd, MMMM, yyyy";
+    }
+
+    Disabled = AdditionalAttributes?.GetValueOrDefault("disabled") is not null;
+
+    if (typeof(TValue) == typeof(CalendarDateRange) && !Required) return;
+
+    if (Nullable.GetUnderlyingType(typeof(TValue)) == null || Required)
+    {
+      CleanSelectedDateButton = false;
+    }
+  }
+
+  private async Task OnValueChange(TValue? value)
+  {
+    Value = value;
+
+    if (Value is not CalendarDateRange)
+    {
+      await CloseCalendar();
+    }
+
+    if (ValueChanged is not null)
+    {
+      await ValueChanged.Value.InvokeAsync(value);
+    }
+  }
+
+  private async Task CleanValue()
+  {
+    if (Disabled) return;
+
+    Value = default;
+
+    if (ValueChanged is not null)
+    {
+      await ValueChanged.Value.InvokeAsync(default);
+    }
+  }
+
+  protected override async Task OnAfterRenderAsync(bool firstRender)
+  {
+    if (firstRender)
+    {
+      _jsDropdownRender = await JS.InvokeAsync<IJSObjectReference>(
+        "import",
+        "./Components/DatePicker/DatePicker.razor.js"
+      );
+    }
+
+    await base.OnAfterRenderAsync(firstRender);
+  }
+
+  public async Task OpenCalendar()
+  {
+    if (Disabled) return;
+
+    _open = true;
+
+    if (_jsDropdownRender is not null)
+    {
+      _jsDropdownCleaner = await _jsDropdownRender.InvokeAsync<IJSObjectReference>("ComputeDialogPosition", _datePickerTriggerRef,
+        _datePickerContentRef,
+        _csSelectRef,
+        nameof(CloseCalendar)
+      );
+    }
+  }
+
+  [JSInvokable]
+  public async Task CloseCalendar()
+  {
+    _open = false;
+
+    if (_jsDropdownCleaner is not null)
+    {
+      await _jsDropdownCleaner.InvokeVoidAsync("CleanUpPosition");
+    }
+  }
+
+}

--- a/src/Pango.UI/Components/DatePicker/DatePicker.razor.cs
+++ b/src/Pango.UI/Components/DatePicker/DatePicker.razor.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Components;
+using TailwindMerge;
+
+namespace Pango.UI.Components;
+
+public partial class DatePicker<TValue>
+{
+    [Parameter] public bool WithMonthAndYearSelection { get; set; }
+    [Parameter] public CalendarDateRangeBehavior Behavior { get; set; } = CalendarDateRangeBehavior.KeepFromMoveTo;
+    [Parameter] public bool Required { get; set; }
+    [Parameter] public DateTime MinDate { get; set; } = DateTime.MinValue;
+    [Parameter] public DateTime MaxDate { get; set; } = DateTime.MaxValue;
+    [Parameter] public bool FixedHeight { get; set; } = true;
+    [Parameter] public DayOfWeek WeekStart { get; set; } = DayOfWeek.Sunday;
+
+    /// <summary>
+    /// Gets or sets a collection of additional attributes that will be applied to the created element.
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
+
+    [Inject]
+    protected TwMerge TwMerge { get; set; } = null!;
+
+    /// <summary>
+    /// Merge Tailwind CSS classes without style conflicts
+    /// </summary>
+    private string? Tw(params string?[] classNames) => TwMerge.Merge(classNames);
+}
+
+public enum Sizes
+{
+    Default,
+    Sm,
+}

--- a/src/Pango.UI/Components/DatePicker/DatePicker.razor.js
+++ b/src/Pango.UI/Components/DatePicker/DatePicker.razor.js
@@ -1,0 +1,56 @@
+import { computePosition, flip, shift, autoUpdate, offset } from 'https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.4/+esm';
+
+export async function ComputeDialogPosition(
+    anchorElement,
+    dialogElement,
+    callbackInstance,
+    callbackName
+) {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+
+    async function updatePosition() {
+        const {x, y} = await computePosition(anchorElement, dialogElement, {
+            placement: "bottom-start",
+            middleware: [flip(), shift(), offset(10)],
+        });
+
+        Object.assign(dialogElement.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+        });
+    }
+
+    const positionCleaner = autoUpdate(
+        anchorElement,
+        dialogElement,
+        updatePosition,
+    )
+
+    if (!dialogElement.open && !!dialogElement.showModal) {
+        dialogElement.showModal();
+
+        window.scrollTo(scrollX, scrollY);
+
+        dialogElement.addEventListener('click', (event) => {
+            if(event.target === dialogElement)
+            {
+                dialogElement.close();
+            }
+        });
+
+        dialogElement.addEventListener('close', () => {
+            callbackInstance.invokeMethodAsync(callbackName)
+        });
+    }
+
+    return {
+        CleanUpPosition: () => {
+            if (dialogElement.open && !!dialogElement.close) {
+                dialogElement.close();
+            }
+
+            positionCleaner()
+        }
+    };
+}

--- a/src/Pango.UI/Docs/Components/DatePicker/DatePicker.mdx
+++ b/src/Pango.UI/Docs/Components/DatePicker/DatePicker.mdx
@@ -1,0 +1,59 @@
+```json :pango-ui-document-metadata
+{
+  "Title": "DatePicker",
+  "Description": "A date picker component that opens the calendar to select a date or a range of dates.",
+  "Featured": true,
+  "IsComponent": true,
+  "Tags": ["UI", "Interactive"],
+  "Sections": [
+    { "Title": "Properties" },
+    { "Title": "Installation" },
+    {
+      "Title": "Examples",
+      "Sections": [
+        { "Id": "range", "Title": "Date Range" },
+        { "Id": "usage", "Title": "Usage" }
+      ]
+    }
+  ]
+}
+```
+
+# DatePicker
+
+A date picker component that opens the calendar to select a date or a range of dates.
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesDatePickerDefault.razor" >
+    <ExamplesDatePickerDefault />
+</ComponentPreview>
+
+## Properties
+
+- **Same as Calendar:** The `DatePicker` component has all the same properties as the `Calendar` component and a bit more.
+- **CleanSelectedDateButton:** A button to clear the selected date, who would have guessed...
+- **DateFormat:** A string to format the date however you want.
+- **Disabled:** If you need to dynamically change the disabled state use the parameter, if you just want to statically disable
+you can just use the HTML disabled property.
+
+**_NOTE:_** To avoid horizontal shift on the calendar, try using a fixed width on the trigger, the calendar will always
+pop up at the start of the trigger.
+
+## Installation
+
+<Code Language="fish" class="py-2">dotnet pango add calendar</Code>
+then
+<Code Language="fish" class="py-2">dotnet pango add date-picker</Code>
+
+## Examples
+
+### Date Range
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesDatePickerRange.razor" >
+    <ExamplesDatePickerRange />
+</ComponentPreview>
+
+### Usage
+
+<ComponentPreview CodeSrc="Docs/Snippets/ExamplesDatePickerEditForm.razor" >
+    <ExamplesDatePickerEditForm />
+</ComponentPreview>

--- a/src/Pango.UI/Docs/Components/DatePicker/Examples/ExamplesDatePickerDefault.razor
+++ b/src/Pango.UI/Docs/Components/DatePicker/Examples/ExamplesDatePickerDefault.razor
@@ -1,0 +1,14 @@
+<DatePicker TValue="DateTime" @bind-Value="_date" />
+
+<span class="px-3 rounded-md border border-primary text-primary py-1.5">@(_date)</span>
+
+<DatePicker TValue="DateOnly?" WithMonthAndYearSelection="true" @bind-Value="_dateOnly" />
+
+<span class="px-3 rounded-md border border-primary text-primary py-1.5">@(_dateOnly)</span>
+
+@code {
+
+  DateTime _date = new(2004, 3, 17);
+  DateOnly? _dateOnly;
+
+}

--- a/src/Pango.UI/Docs/Components/DatePicker/Examples/ExamplesDatePickerEditForm.razor
+++ b/src/Pango.UI/Docs/Components/DatePicker/Examples/ExamplesDatePickerEditForm.razor
@@ -1,0 +1,59 @@
+@using System.ComponentModel.DataAnnotations
+
+<div class="flex flex-col gap-6 items-center">
+  <EditForm Model="@this" FormName="birthday-example-form" Enhance OnValidSubmit="@HandleSubmit" class="flex flex-col gap-6">
+    <DataAnnotationsValidator/>
+    <div class="flex flex-col gap-2">
+      <label class="font-semibold">Insert your next birthday</label>
+      <DatePicker TValue="DateOnly?" @bind-Value="SelectedDay" CleanSelectedDateButton="false" WithMonthAndYearSelection="true"/>
+    </div>
+    @if (_submitted)
+    {
+      <ValidationMessage class="text-sm text-destructive" For="@(() => SelectedDay)"/>
+    }
+    <Button type="submit">
+      Submit
+    </Button>
+  </EditForm>
+  @if (_birthday != DateOnly.MinValue)
+  {
+    <Alert Variant="@(Alert.Variants.Sucess)" OnDismiss="@(() => _birthday = DateOnly.MinValue)">
+      <AlertSide>
+        <i class="ph ph-check text-lg"></i>
+      </AlertSide>
+      <AlertTitle>Success</AlertTitle>
+      <AlertDescription>
+        <div class="flex flex-col gap-2">
+          <span>Your next birthday is: <strong class="font-medium">@_birthday</strong></span>
+
+          @if (_today == _birthday)
+          {
+            <span>🎉🥳<strong>Happy Birthday!!!</strong>🥳🎉</span>
+          }
+        </div>
+      </AlertDescription>
+    </Alert>
+  }
+</div>
+
+@code {
+  bool _submitted;
+  DateOnly _today = DateOnly.FromDateTime(DateTime.Today);
+
+  [SupplyParameterFromForm]
+  [Display(Name = "Birth Day")]
+  [Required(ErrorMessage = "Please insert your birth day.")]
+  public DateOnly? SelectedDay { get; set; }
+
+  DateOnly _birthday;
+
+
+  private void HandleSubmit()
+  {
+    _submitted = true;
+    if (SelectedDay is null) return;
+
+    _birthday = SelectedDay.Value;
+  }
+
+}

--- a/src/Pango.UI/Docs/Components/DatePicker/Examples/ExamplesDatePickerRange.razor
+++ b/src/Pango.UI/Docs/Components/DatePicker/Examples/ExamplesDatePickerRange.razor
@@ -1,0 +1,20 @@
+<DatePicker class="w-sm" TValue="CalendarDateRange" Required="true" DateFormat="dd/MM/yyyy" @bind-Value="_range" />
+
+<span class="flex flex-col gap-2 px-3 rounded-md border border-primary text-primary py-1.5">
+  <span>From: @(_range.From)</span>
+  <span>To: @(_range.To)</span>
+</span>
+
+<DatePicker class="w-sm" TValue="CalendarDateRange" Behavior="CalendarDateRangeBehavior.AlwaysSelectNewRange" @bind-Value="_range2" />
+
+<span class="flex flex-col gap-2 px-3 rounded-md border border-primary text-primary py-1.5">
+  <span>From: @(_range2?.From)</span>
+  <span>To: @(_range2?.To)</span>
+</span>
+
+@code {
+
+  CalendarDateRange _range = new() {From = new (2004, 3, 17), To = new(2004, 3, 22)};
+  CalendarDateRange? _range2;
+
+}

--- a/src/Pango.UI/Pages/Home.razor
+++ b/src/Pango.UI/Pages/Home.razor
@@ -55,6 +55,7 @@
     new("CheckboxGroup", "./docs/checkbox-group"),
     new("Code", "./docs/code"),
     new("DataTable", "./docs/data-table"),
+    new("DatePicker", "./docs/date-picker"),
     new("Dialog", "./docs/dialog"),
     new("DropdownMenu", "./docs/dropdown-menu"),
     new("Input", "./docs/input"),


### PR DESCRIPTION
Simple date picker component that opens the [`Calendar`](https://github.com/kallebysantos/pango-ui/blob/dev/src/Pango.UI/Components/Calendar/Calendar.razor) component

## Parameters
- **Same as Calendar:** The `DatePicker` component has all the same properties as the `Calendar` component and a bit more.
- **CleanSelectedDateButton:** A button to clear the selected date 😐
- **DateFormat:** A string to format the date however you want.
- **Disabled:** If you need to dynamically change the disabled state use the parameter, if you just want to statically disable
you can just use the HTML disabled property.

![CatCatMemeGIF](https://github.com/user-attachments/assets/002f1810-33ca-449b-ba8c-09fc4294ed7e)
